### PR TITLE
README.md changes related to ES6 modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,6 @@ Applications that run on Node.js v13 and above can import commerce-sdk-react as 
 You can import the SDK using `import CommerceSdkReact from "commerce-sdk-react";` syntax on Node.js v13 and above. Node will treat the files ending with `.mjs` as ES module by default or when the nearest parent package.json file contains a top-level field "type" with a value of "module". 
 Refer to [Enabling ECMAScript Modules](https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_enabling) for additional information to enable ES module support.
 
-```javascript
-//file name -> app.mjs
-import CommerceSdkReact from "commerce-sdk-react";
-```
-
 For Node.js v12 and below only `require` is supported. 
 
 ## Testing


### PR DESCRIPTION
Readme changes related to ES modules import syntax. There are no code changes required other than using appropriate node version. Node versions 13 and above support ECMA modules by default while versions 10 to 12 requires --experimental-modules flag. 

