### PR TITLE
Updated readme to reference the commerce sdk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# https://help.github.com/en/enterprise/2.17/user/articles/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+
+*       @SalesforceCommerceCloud/dx-runtime

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI][circleci-image]][circleci-url]
 
-The Salesforce Commerce SDK Isomorphic allows easy interaction with the Salesforce B2C Commerce platform Shopper APIs through a lightweight SDK that works both on browsers and nodejs applications.  If you are looking for a more fully features SDK that includes our B2C Data APIs in addition to the Shopper APIs please refer to our [Commerce SDK](https://github.com/SalesforceCommerceCloud/commerce-sdk).
+The Salesforce Commerce SDK Isomorphic allows easy interaction with the Salesforce B2C Commerce platform Shopper APIs through a lightweight SDK that works both on browsers and nodejs applications.  If you are looking for a more fully features SDK...' to "For a more robust SDK, which includes our B2C Data APIS and Shopper APIs, see [our Node.js Commerce SDK](https://github.com/SalesforceCommerceCloud/commerce-sdk).
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI][circleci-image]][circleci-url]
 
-The Salesforce Commerce SDK Isomorphic allows easy interaction with the Salesforce B2C Commerce platform Shopper APIs.
+The Salesforce Commerce SDK Isomorphic allows easy interaction with the Salesforce B2C Commerce platform Shopper APIs through a lightweight SDK that works both on browsers and nodejs applications.  If you are looking for a more fully features SDK that includes our B2C Data APIs in addition to the Shopper APIs please refer to our [Commerce SDK](https://github.com/SalesforceCommerceCloud/commerce-sdk).
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI][circleci-image]][circleci-url]
 
-The Salesforce Commerce SDK Isomorphic allows easy interaction with the Salesforce B2C Commerce platform Shopper APIs through a lightweight SDK that works both on browsers and nodejs applications.  If you are looking for a more fully features SDK...' to "For a more robust SDK, which includes our B2C Data APIS and Shopper APIs, see [our Node.js Commerce SDK](https://github.com/SalesforceCommerceCloud/commerce-sdk).
+The Salesforce Commerce SDK Isomorphic allows easy interaction with the Salesforce B2C Commerce platform Shopper APIs through a lightweight SDK that works both on browsers and nodejs applications.  For a more robust SDK, which includes our B2C Data APIS and Shopper APIs, see [our Node.js Commerce SDK](https://github.com/SalesforceCommerceCloud/commerce-sdk).
 
 ## Building
 


### PR DESCRIPTION
Just thought we should reference our other sdk at the top of this readme.