### PR TITLE
Add option to transform request body

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+// This file is used by jest
 module.exports = {
+  plugins: ['@babel/plugin-proposal-class-properties'],
   presets: [
     [
       '@babel/preset-env',

--- a/babel.config.rollup.js
+++ b/babel.config.rollup.js
@@ -7,6 +7,7 @@
 const pkg = require('./package.json');
 
 module.exports = {
+  plugins: ['@babel/plugin-proposal-class-properties'],
   presets: [
     [
       '@babel/preset-env',

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   "devDependencies": {
     "@babel/cli": "7.10.5",
     "@babel/core": "7.10.5",
+    "@babel/plugin-proposal-class-properties": "^7.12.13",
     "@babel/preset-env": "7.10.4",
     "@babel/preset-react": "7.10.1",
     "@babel/preset-typescript": "^7.10.4",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@testing-library/react-hooks": "3.4.1",
     "@testing-library/user-event": "12.0.17",
     "@types/fs-extra": "^9.0.1",
+    "@types/node-fetch": "^2.5.8",
     "@typescript-eslint/eslint-plugin": "^4.6.1",
     "@typescript-eslint/parser": "^4.6.1",
     "autoprefixer": "9.8.5",

--- a/src/static/clientConfig.test.ts
+++ b/src/static/clientConfig.test.ts
@@ -66,15 +66,23 @@ test('that clientConfig clones correctly', () => {
 
 test('default transform request should only transform plain objects', () => {
   const transform = ClientConfig.defaults.transformRequest;
-  // non-objects should not be modified
-  expect(transform(null)).toBeNull();
-  expect(transform(undefined)).toBeUndefined();
-  expect(transform('a string')).toBe('a string');
+  let headers = {};
+  // non-objects should not be modified, and should not modify headers
+  expect(transform(null, headers)).toBeNull();
+  expect(headers).toEqual({});
+  expect(transform(undefined, {})).toBeUndefined();
+  expect(headers).toEqual({});
+  expect(transform('a string', {})).toBe('a string');
+  expect(headers).toEqual({});
   // instances of classes should not be modified
   const blob = new Blob();
-  expect(transform(blob)).toBe(blob);
-  // plain objects should be converted to JSON
-  expect(transform({ plain: 'object' })).toBe('{"plain":"object"}');
+  expect(transform(blob, {})).toBe(blob);
+  expect(headers).toEqual({});
+  // plain objects should be converted to JSON and set Content-Type to stuff
+  expect(transform({ plain: 'object' }, headers)).toBe('{"plain":"object"}');
+  expect(headers).toEqual({ 'Content-Type': 'application/json' });
+  headers = {};
   const protoless = Object.create(null);
-  expect(transform(protoless)).toBe('{}');
+  expect(transform(protoless, headers)).toBe('{}');
+  expect(headers).toEqual({ 'Content-Type': 'application/json' });
 });

--- a/src/static/clientConfig.ts
+++ b/src/static/clientConfig.ts
@@ -10,38 +10,41 @@ import type { UrlParameters } from './commonParameters';
 // eslint-disable-next-line no-undef
 type BrowserRequestInit = RequestInit; // alias for clarity
 
+export interface ClientConfigInit {
+  baseUri?: string;
+  proxy?: string;
+  headers?: { [key: string]: string };
+  parameters?: UrlParameters;
+  fetchOptions?: BrowserRequestInit & NodeRequestInit;
+}
+
 /**
  * Configuration parameters common to Commerce SDK clients
  */
-export default class ClientConfig {
+export default class ClientConfig implements ClientConfigInit {
   public baseUri?: string;
 
   public proxy?: string;
 
-  public headers?: { [key: string]: string };
+  public headers: { [key: string]: string };
 
-  public parameters?: UrlParameters;
+  public parameters: UrlParameters;
 
-  public fetchOptions?: BrowserRequestInit & NodeRequestInit;
+  public fetchOptions: BrowserRequestInit & NodeRequestInit;
 
-  constructor(config?: ClientConfig) {
-    if (!config) {
-      return;
-    }
+  constructor(config = ClientConfig.defaults) {
+    this.headers = { ...config.headers };
+    this.parameters = { ...config.parameters };
+    this.fetchOptions = { ...config.fetchOptions };
+
+    // Optional properties
     if (config.baseUri) {
       this.baseUri = config.baseUri;
     }
     if (config.proxy) {
       this.proxy = config.proxy;
     }
-    if (config.headers) {
-      this.headers = { ...config.headers };
-    }
-    if (config.parameters) {
-      this.parameters = { ...config.parameters };
-    }
-    if (config.fetchOptions) {
-      this.fetchOptions = { ...config.fetchOptions };
-    }
   }
+
+  static readonly defaults: ClientConfigInit = {};
 }

--- a/src/static/clientConfig.ts
+++ b/src/static/clientConfig.ts
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import type { RequestInit as NodeRequestInit } from 'node-fetch';
+import type { UrlParameters } from './commonParameters';
+
+// eslint-disable-next-line no-undef
+type BrowserRequestInit = RequestInit; // alias for clarity
 
 /**
  * Configuration parameters common to Commerce SDK clients
@@ -15,9 +20,9 @@ export default class ClientConfig {
 
   public headers?: { [key: string]: string };
 
-  public parameters?: { [ key: string]: unknown };
+  public parameters?: UrlParameters;
 
-  public fetchOptions?: { [key: string]: unknown };
+  public fetchOptions?: BrowserRequestInit & NodeRequestInit;
 
   constructor(config?: ClientConfig) {
     if (!config) {

--- a/src/static/clientConfig.ts
+++ b/src/static/clientConfig.ts
@@ -17,7 +17,7 @@ export interface ClientConfigInit {
   parameters?: UrlParameters;
   fetchOptions?: FetchOptions;
   // eslint-disable-next-line no-unused-vars
-  transformRequest?: (data: any, headers?: { [key: string]: string }) => Required<FetchOptions>['body'];
+  transformRequest?: (data: any, headers: { [key: string]: string }) => Required<FetchOptions>['body'];
 }
 
 /**
@@ -53,17 +53,22 @@ export default class ClientConfig implements ClientConfigInit {
 
   static readonly defaults: Pick<Required<ClientConfigInit>, 'transformRequest'> = {
     /**
-     * Transforms data into a JSON string if it is a plain object, otherwise
-     * returns the data unmodified.
-     * @param data Data to transform
+     * If data is a plain object, converts it to JSON and sets the Content-Type header
+     * to application/json. All other data is returned unmodified.
+     * @param data - Data to transform
      * @returns A JSON string or the unmodified data
      */
-    transformRequest<T>(data: T): T | string {
+    transformRequest<T>(data: T, headers: { [key: string]: string }): T | string {
       if (data == null || typeof data !== 'object') {
         return data;
       }
       const proto = Object.getPrototypeOf(data);
-      return proto === null || proto === Object.prototype ? JSON.stringify(data) : data;
+      if (proto === null || proto === Object.prototype) {
+        // eslint-disable-next-line no-param-reassign
+        headers['Content-Type'] = 'application/json';
+        return JSON.stringify(data);
+      }
+      return data;
     },
   };
 }

--- a/src/static/commonParameters.ts
+++ b/src/static/commonParameters.ts
@@ -22,3 +22,13 @@ export type CommonParameters = {
   siteId?: string;
   version?: string;
 };
+
+export interface PathParameters {
+  [key: string]: string | number | boolean;
+}
+
+export interface QueryParameters {
+  [key: string]: string | number | boolean | string[] | number[];
+}
+
+export type UrlParameters = PathParameters | QueryParameters;

--- a/src/static/templateUrl.ts
+++ b/src/static/templateUrl.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import type { PathParameters, QueryParameters } from './commonParameters';
+
 export default class TemplateURL extends URL {
   /**
    * @param url -
@@ -13,8 +15,8 @@ export default class TemplateURL extends URL {
     url: string,
     base?: string,
     parameters?: {
-      pathParams?: { [key: string]: unknown },
-      queryParams?: { [key: string]: unknown },
+      pathParams?: PathParameters,
+      queryParams?: QueryParameters,
       origin?: string
     },
   ) {
@@ -49,16 +51,16 @@ export default class TemplateURL extends URL {
    * are allowed and are appended using the "repeat" convention where the \{ a:
    * ["1", "2"] \} becomes "?a=1&a=2"
    */
-  addQueryParams(queryParams: {[key: string]: unknown} | undefined): void {
+  addQueryParams(queryParams?: QueryParameters): void {
     if (queryParams) {
       Object.keys(queryParams).forEach((key) => {
-        if (Array.isArray(queryParams[key])) {
-          const paramArr = queryParams[key] as unknown[];
-          for (let i = 0; i < paramArr.length; i += 1) {
-            this.searchParams.append(key, String(paramArr[i]));
+        const param = queryParams[key];
+        if (Array.isArray(param)) {
+          for (let i = 0; i < param.length; i += 1) {
+            this.searchParams.append(key, String(param[i]));
           }
         } else {
-          this.searchParams.append(key, String(queryParams[key]));
+          this.searchParams.append(key, String(param));
         }
       });
     }
@@ -74,7 +76,7 @@ export default class TemplateURL extends URL {
    */
   static renderTemplateUri(
     template: string,
-    parameters: { [key: string]: unknown } | undefined,
+    parameters?: PathParameters,
   ): string {
     return parameters ? template.replace(
       /\{([^\}]+)\}/g, /* eslint-disable-line no-useless-escape */

--- a/src/test/crossFetchNode.test.ts
+++ b/src/test/crossFetchNode.test.ts
@@ -6,7 +6,7 @@
  */
 
 import nock from 'nock';
-import { ClientConfig, ShopperCustomers, ShopperSearch } from '../lib';
+import { ClientConfigInit, ShopperCustomers, ShopperSearch } from '../lib';
 import config from '../environment/config';
 
 /**
@@ -96,7 +96,7 @@ test('should use timeout from fetch options and throw timeout error', async () =
     .delayConnection(400)
     .reply(200, {}, { 'content-type': 'application-json charset=UTF-8' });
 
-  const clientConfig: ClientConfig = {
+  const clientConfig: ClientConfigInit = {
     ...config,
     fetchOptions: {
       timeout: 200,
@@ -119,7 +119,7 @@ test('should use timeout from fetch options and succeed when service responds qu
     .matchHeader('authorization', 'Bearer test-auth')
     .reply(200, {}, { 'content-type': 'application-json charset=UTF-8' });
 
-  const clientConfig: ClientConfig = {
+  const clientConfig: ClientConfigInit = {
     ...config,
     fetchOptions: {
       timeout: 1000,
@@ -140,7 +140,7 @@ test('should use default value when timeout is not configured in fetch options a
     .delayConnection(400)
     .reply(200, {}, { 'content-type': 'application-json charset=UTF-8' });
 
-  const clientConfig: ClientConfig = {
+  const clientConfig: ClientConfigInit = {
     ...config,
     fetchOptions: {},
   };
@@ -158,7 +158,7 @@ test('should not fail when arbitrary parameters are configured in fetchOptions',
     .matchHeader('authorization', 'Bearer test-auth')
     .reply(200, {}, { 'content-type': 'application-json charset=UTF-8' });
 
-  const clientConfig: ClientConfig = {
+  const clientConfig: ClientConfigInit = {
     ...config,
     fetchOptions: {
       somekey: 'some value',

--- a/src/test/crossFetchNode.test.ts
+++ b/src/test/crossFetchNode.test.ts
@@ -108,7 +108,7 @@ test('should use timeout from fetch options and throw timeout error', async () =
   await expect(client.productSearch({
     parameters: { q: 'sony' }, headers: { authorization: 'Bearer test-auth' },
   })).rejects.toEqual({
-    message: 'network timeout at: https://localhost:3000/search/shopper-search/v1/organizations/ORGANIZATION_ID/product-search?siteId=SITE_ID&q=sony',
+    message: 'network timeout at: https://localhost:3000/search/shopper-search/v1/organizations/ORGANIZATION_ID/product-search?q=sony&siteId=SITE_ID',
     type: 'request-timeout',
   });
 });

--- a/src/test/crossFetchNode.test.ts
+++ b/src/test/crossFetchNode.test.ts
@@ -6,7 +6,7 @@
  */
 
 import nock from 'nock';
-import { ShopperCustomers, ShopperSearch } from '../lib';
+import { ClientConfig, ShopperCustomers, ShopperSearch } from '../lib';
 import config from '../environment/config';
 
 /**
@@ -96,12 +96,10 @@ test('should use timeout from fetch options and throw timeout error', async () =
     .delayConnection(400)
     .reply(200, {}, { 'content-type': 'application-json charset=UTF-8' });
 
-  const clientConfig = {
+  const clientConfig: ClientConfig = {
     ...config,
-    ...{
-      fetchOptions: {
-        timeout: 200,
-      },
+    fetchOptions: {
+      timeout: 200,
     },
   };
 
@@ -121,12 +119,10 @@ test('should use timeout from fetch options and succeed when service responds qu
     .matchHeader('authorization', 'Bearer test-auth')
     .reply(200, {}, { 'content-type': 'application-json charset=UTF-8' });
 
-  const clientConfig = {
+  const clientConfig: ClientConfig = {
     ...config,
-    ...{
-      fetchOptions: {
-        timeout: 1000,
-      },
+    fetchOptions: {
+      timeout: 1000,
     },
   };
 
@@ -144,12 +140,9 @@ test('should use default value when timeout is not configured in fetch options a
     .delayConnection(400)
     .reply(200, {}, { 'content-type': 'application-json charset=UTF-8' });
 
-  const clientConfig = {
+  const clientConfig: ClientConfig = {
     ...config,
-    ...{
-      fetchOptions: {
-      },
-    },
+    fetchOptions: {},
   };
 
   const client = new ShopperSearch(clientConfig);
@@ -165,14 +158,12 @@ test('should not fail when arbitrary parameters are configured in fetchOptions',
     .matchHeader('authorization', 'Bearer test-auth')
     .reply(200, {}, { 'content-type': 'application-json charset=UTF-8' });
 
-  const clientConfig = {
+  const clientConfig: ClientConfig = {
     ...config,
-    ...{
-      fetchOptions: {
-        somekey: 'some value',
-        timeout: 1000,
-      },
-    },
+    fetchOptions: {
+      somekey: 'some value',
+      timeout: 1000,
+    } as any,
   };
 
   const client = new ShopperSearch(clientConfig);

--- a/templates/client.ts.hbs
+++ b/templates/client.ts.hbs
@@ -1,4 +1,4 @@
-import ClientConfig from "./clientConfig";
+import ClientConfig, { ClientConfigInit } from "./clientConfig";
 import TemplateURL from "./templateUrl";
 import { fetch, Request }  from "cross-fetch";
 import type { PathParameters, QueryParameters, UrlParameters } from "./commonParameters";
@@ -44,12 +44,13 @@ export type {{getValue name}} = {{> dtoPartial typeDto=this}}
 export class {{name.upperCamelCase}} {
   public clientConfig: ClientConfig;
 
-  constructor(config = new ClientConfig()) {
-    this.clientConfig = new ClientConfig(config);
+  static readonly defaultBaseUri = "{{getBaseUriFromDocument model}}";
 
-    if (!this.clientConfig.baseUri) {
-      this.clientConfig.baseUri = "{{getBaseUriFromDocument model}}";
-    }
+  constructor(config?: ClientConfigInit) {
+    this.clientConfig = new ClientConfig({
+      baseUri: new.target.defaultBaseUri,
+      ...config
+    });
   }
 
   {{> operationsPartial model}}

--- a/templates/client.ts.hbs
+++ b/templates/client.ts.hbs
@@ -1,6 +1,7 @@
 import ClientConfig from "./clientConfig";
 import TemplateURL from "./templateUrl";
 import { fetch, Request }  from "cross-fetch";
+import type { PathParameters, QueryParameters, UrlParameters } from "./commonParameters";
 
 {{#each dataTypes}}
     {{#if (or (isTypeDefinition this) (isArrayType this))}}

--- a/templates/index.ts.hbs
+++ b/templates/index.ts.hbs
@@ -1,16 +1,9 @@
 {{#each children}}
-import { {{~name.upperCamelCase~}} } from "./{{name.lowerCamelCase}}";
+export { {{name.upperCamelCase}} } from "./{{name.lowerCamelCase}}";
 {{/each}}
-import {CommonParameters} from "./commonParameters";
+export type { ClientConfigInit } from "./clientConfig";
+export type { CommonParameters } from "./commonParameters";
+// Can't currently use `export from` with default exports
 import ClientConfig from "./clientConfig";
 import TemplateURL from "./templateUrl";
-
-export {
-{{#each children}}
-  {{name.upperCamelCase}},
-{{/each}}
-  ClientConfig,
-  TemplateURL,
-}
-
-export type { CommonParameters };
+export { ClientConfig, TemplateURL };

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -142,7 +142,7 @@
       } else if (configParams["{{{name}}}"]) {
         queryParams["{{{name}}}"] = configParams["{{{name}}}"];
       {{/if}}
-      }
+      };
       {{/each}}
 
       const url = new TemplateURL(
@@ -165,7 +165,7 @@
         url.toString(),
         {
           ...this.clientConfig.fetchOptions,
-          {{#or (is method "patch") (is method "post") (is method "put")}}body: JSON.stringify(options?.body),{{/or}}
+          {{#or (is method "patch") (is method "post") (is method "put")}}body: this.clientConfig.transformRequest(options.body, headers),{{/or}}
           headers: headers,
           method: "{{loud method}}"
         }

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -123,7 +123,6 @@
       const configParams = this.clientConfig.parameters || {};
 
       const pathParams = {
-        version: 'v1',
       {{#each ../parameters}}
         "{{{name}}}": optionParams["{{{name}}}"]
         {{! if it is a common path parameter, fall back to client config }}
@@ -133,23 +132,27 @@
       // Type assertion is safe because the object is generated from known params
       } as PathParameters;
 
-      const queryParams: QueryParameters = {};
+      // Query parameters are assumed to be any parameters that aren't path parameters
+      const queryParams = { ...optionParams } as QueryParameters;
+      // Delete path parameters
+      {{#each ../parameters}}
+      delete queryParams["{{{name}}}"];
+      {{/each}}
+      // Fall back to config for common query parameters
       {{#each request.queryParameters}}
-      if (optionParams["{{{name}}}"]) {
-        queryParams["{{{name}}}"] = optionParams["{{{name}}}"];
       {{#if (isCommonQueryParameter name)}}
-      {{! if it is a common query parameter, fall back to client config }}
-      } else if (configParams["{{{name}}}"]) {
+      if (queryParams["{{{name}}}"] === undefined && configParams["{{{name}}}"] !== undefined) {
         queryParams["{{{name}}}"] = configParams["{{{name}}}"];
+      }
       {{/if}}
-      };
       {{/each}}
 
       const url = new TemplateURL(
         "{{{../path}}}",
         this.clientConfig.baseUri,
         {
-          pathParams,
+          // All unknown params from optionParams are passed as both path and query params
+          pathParams: { version: 'v1', ...optionParams as PathParameters, ...pathParams },
           queryParams,
           origin: this.clientConfig.proxy
         }

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -119,41 +119,39 @@
       },
       rawResponse?: boolean,
     ): Promise<Response | {{getReturnTypeFromOperation this}}> {
+      const optionParams = options?.parameters || {} as UrlParameters;
+      const configParams = this.clientConfig.parameters || {};
 
-      const parameters = (options && options.parameters) ? options.parameters : {} as {[key: string]: string};
-
-      const pathParameters = {
+      const pathParams = {
+        version: 'v1',
       {{#each ../parameters}}
-        "{{{name}}}": parameters["{{{name}}}"]
-        {{! if it is a common path parameter, fallback to client config for undefined }}
-        {{#if (isCommonPathParameter name)}} !== undefined ? parameters["{{{name}}}"] : this.clientConfig.parameters?.{{{name}}}{{/if}}
+        "{{{name}}}": optionParams["{{{name}}}"]
+        {{! if it is a common path parameter, fall back to client config }}
+        {{#if (isCommonPathParameter name)}}  ?? configParams["{{{name}}}"]{{/if}}
         {{#unless @last}},{{/unless}}
       {{/each}}
-      };
+      // Type assertion is safe because the object is generated from known params
+      } as PathParameters;
 
-      const queryParameters: { [key: string]: string } = {};
-      (Object.keys(parameters) as Array<keyof typeof parameters>).forEach(key => {
-        if (!(key in pathParameters)) {
-          queryParameters[key] = parameters[key] as string;
-        }
-      });
-
+      const queryParams: QueryParameters = {};
       {{#each request.queryParameters}}
-        {{! for queryParameters that are common query parameters, fallback to client config for undefined }}
-        {{#if (isCommonQueryParameter name)}}
-        queryParameters.{{{name}}} =
-          queryParameters["{{{name}}}"] !== undefined
-            ? String(parameters["{{{name}}}"]) : String(this.clientConfig.parameters?.{{{name}}});
-        {{/if}}
+      if (optionParams["{{{name}}}"]) {
+        queryParams["{{{name}}}"] = optionParams["{{{name}}}"];
+      {{#if (isCommonQueryParameter name)}}
+      {{! if it is a common query parameter, fall back to client config }}
+      } else if (configParams["{{{name}}}"]) {
+        queryParams["{{{name}}}"] = configParams["{{{name}}}"];
+      {{/if}}
+      }
       {{/each}}
 
       const url = new TemplateURL(
         "{{{../path}}}",
         this.clientConfig.baseUri,
         {
-          pathParams: { version: 'v1', ...this.clientConfig.parameters, ...pathParameters },
-          queryParams: { siteId: this.clientConfig.parameters?.siteId, ...queryParameters},
-          origin: this.clientConfig?.proxy
+          pathParams,
+          queryParams,
+          origin: this.clientConfig.proxy
         }
       );
 

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -157,7 +157,7 @@
 
       const headers = {
         "Content-Type": "application/json",
-        ...this.clientConfig?.headers,
+        ...this.clientConfig.headers,
         ...options?.headers
       };
 

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -156,7 +156,6 @@
       );
 
       const headers = {
-        "Content-Type": "application/json",
         ...this.clientConfig.headers,
         ...options?.headers
       };
@@ -166,7 +165,7 @@
         {
           ...this.clientConfig.fetchOptions,
           {{#or (is method "patch") (is method "post") (is method "put")}}body: this.clientConfig.transformRequest(options.body, headers),{{/or}}
-          headers: headers,
+          headers,
           method: "{{loud method}}"
         }
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,6 +25,13 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
+"@babel/code-frame@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
+  integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
+  dependencies:
+    "@babel/highlight" "^7.12.13"
+
 "@babel/compat-data@^7.10.4", "@babel/compat-data@^7.12.1", "@babel/compat-data@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.5.tgz#f56db0c4bb1bbbf221b4e81345aab4141e7cb0e9"
@@ -83,6 +90,15 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/generator@^7.12.17":
+  version "7.12.17"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.17.tgz#9ef1dd792d778b32284411df63f4f668a9957287"
+  integrity sha512-DSA7ruZrY4WI8VxuS1jWSRezFnghEoYEFrZcw9BizQRmOZiUsiHl59+qEARGPqPikwA/GPTyRCi7isuCK/oyqg==
+  dependencies:
+    "@babel/types" "^7.12.17"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
 "@babel/helper-annotate-as-pure@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz#5bf0d495a3f757ac3bda48b5bf3b3ba309c72ba3"
@@ -136,6 +152,17 @@
     "@babel/helper-replace-supers" "^7.12.1"
     "@babel/helper-split-export-declaration" "^7.10.4"
 
+"@babel/helper-create-class-features-plugin@^7.12.13":
+  version "7.12.17"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.17.tgz#704b69c8a78d03fb1c5fcc2e7b593f8a65628944"
+  integrity sha512-I/nurmTxIxHV0M+rIpfQBF1oN342+yvl2kwZUrQuOClMamHF1w5tknfZubgNOLRoA73SzBFAdFcpb4M9HwOeWQ==
+  dependencies:
+    "@babel/helper-function-name" "^7.12.13"
+    "@babel/helper-member-expression-to-functions" "^7.12.17"
+    "@babel/helper-optimise-call-expression" "^7.12.13"
+    "@babel/helper-replace-supers" "^7.12.13"
+    "@babel/helper-split-export-declaration" "^7.12.13"
+
 "@babel/helper-create-regexp-features-plugin@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.1.tgz#18b1302d4677f9dc4740fe8c9ed96680e29d37e8"
@@ -170,12 +197,28 @@
     "@babel/template" "^7.10.4"
     "@babel/types" "^7.10.4"
 
+"@babel/helper-function-name@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz#93ad656db3c3c2232559fd7b2c3dbdcbe0eb377a"
+  integrity sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.12.13"
+    "@babel/template" "^7.12.13"
+    "@babel/types" "^7.12.13"
+
 "@babel/helper-get-function-arity@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz#98c1cbea0e2332f33f9a4661b8ce1505b2c19ba2"
   integrity sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
   dependencies:
     "@babel/types" "^7.10.4"
+
+"@babel/helper-get-function-arity@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz#bc63451d403a3b3082b97e1d8b3fe5bd4091e583"
+  integrity sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==
+  dependencies:
+    "@babel/types" "^7.12.13"
 
 "@babel/helper-hoist-variables@^7.10.4":
   version "7.10.4"
@@ -190,6 +233,13 @@
   integrity sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==
   dependencies:
     "@babel/types" "^7.12.1"
+
+"@babel/helper-member-expression-to-functions@^7.12.13", "@babel/helper-member-expression-to-functions@^7.12.17":
+  version "7.12.17"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.17.tgz#f82838eb06e1235307b6d71457b6670ff71ee5ac"
+  integrity sha512-Bzv4p3ODgS/qpBE0DiJ9qf5WxSmrQ8gVTe8ClMfwwsY2x/rhykxxy3bXzG7AGTnPB2ij37zGJ/Q/6FruxHxsxg==
+  dependencies:
+    "@babel/types" "^7.12.17"
 
 "@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.7.4":
   version "7.12.5"
@@ -220,10 +270,22 @@
   dependencies:
     "@babel/types" "^7.10.4"
 
+"@babel/helper-optimise-call-expression@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz#5c02d171b4c8615b1e7163f888c1c81c30a2aaea"
+  integrity sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==
+  dependencies:
+    "@babel/types" "^7.12.13"
+
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.1", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
   integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
+
+"@babel/helper-plugin-utils@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.12.13.tgz#174254d0f2424d8aefb4dd48057511247b0a9eeb"
+  integrity sha512-C+10MXCXJLiR6IeG9+Wiejt9jmtFpxUc3MQqCmPY8hfCjyUGl9kT+B2okzEZrtykiwrc4dbCPdDoz0A/HQbDaA==
 
 "@babel/helper-regex@^7.10.4":
   version "7.10.5"
@@ -251,6 +313,16 @@
     "@babel/traverse" "^7.12.5"
     "@babel/types" "^7.12.5"
 
+"@babel/helper-replace-supers@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.12.13.tgz#00ec4fb6862546bd3d0aff9aac56074277173121"
+  integrity sha512-pctAOIAMVStI2TMLhozPKbf5yTEXc0OJa0eENheb4w09SrgOWEs+P4nTOZYJQCqs8JlErGLDPDJTiGIp3ygbLg==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.12.13"
+    "@babel/helper-optimise-call-expression" "^7.12.13"
+    "@babel/traverse" "^7.12.13"
+    "@babel/types" "^7.12.13"
+
 "@babel/helper-simple-access@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz#32427e5aa61547d38eb1e6eaf5fd1426fdad9136"
@@ -272,10 +344,22 @@
   dependencies:
     "@babel/types" "^7.11.0"
 
+"@babel/helper-split-export-declaration@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz#e9430be00baf3e88b0e13e6f9d4eaf2136372b05"
+  integrity sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==
+  dependencies:
+    "@babel/types" "^7.12.13"
+
 "@babel/helper-validator-identifier@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
   integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
+
+"@babel/helper-validator-identifier@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
+  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
 
 "@babel/helper-validator-option@^7.12.1":
   version "7.12.1"
@@ -310,10 +394,24 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.12.13.tgz#8ab538393e00370b26271b01fa08f7f27f2e795c"
+  integrity sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.10.5", "@babel/parser@^7.12.3", "@babel/parser@^7.12.5", "@babel/parser@^7.7.0":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.5.tgz#b4af32ddd473c0bfa643bd7ff0728b8e71b81ea0"
   integrity sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==
+
+"@babel/parser@^7.12.13", "@babel/parser@^7.12.17":
+  version "7.12.17"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.17.tgz#bc85d2d47db38094e5bb268fc761716e7d693848"
+  integrity sha512-r1yKkiUTYMQ8LiEI0UcQx5ETw5dpTLn9wijn9hk6KkTtOK95FndDN10M+8/s6k/Ymlbivw0Av9q4SlgF80PtHg==
 
 "@babel/plugin-proposal-async-generator-functions@^7.10.4", "@babel/plugin-proposal-async-generator-functions@^7.12.1":
   version "7.12.1"
@@ -331,6 +429,14 @@
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-proposal-class-properties@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.13.tgz#3d2ce350367058033c93c098e348161d6dc0d8c8"
+  integrity sha512-8SCJ0Ddrpwv4T7Gwb33EmW1V9PY5lggTO+A8WjyIwxrSHDUyBw4MtF96ifn1n8H806YlxbVCoKXbbmzD6RD+cA==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
 "@babel/plugin-proposal-decorators@7.12.1":
   version "7.12.1"
@@ -1128,6 +1234,15 @@
     "@babel/parser" "^7.10.4"
     "@babel/types" "^7.10.4"
 
+"@babel/template@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
+  integrity sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/parser" "^7.12.13"
+    "@babel/types" "^7.12.13"
+
 "@babel/traverse@^7.1.0", "@babel/traverse@^7.10.4", "@babel/traverse@^7.10.5", "@babel/traverse@^7.12.1", "@babel/traverse@^7.12.5", "@babel/traverse@^7.7.0":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.5.tgz#78a0c68c8e8a35e4cacfd31db8bb303d5606f095"
@@ -1143,12 +1258,36 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
+"@babel/traverse@^7.12.13":
+  version "7.12.17"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.17.tgz#40ec8c7ffb502c4e54c7f95492dc11b88d718619"
+  integrity sha512-LGkTqDqdiwC6Q7fWSwQoas/oyiEYw6Hqjve5KOSykXkmFJFqzvGMb9niaUEag3Rlve492Mkye3gLw9FTv94fdQ==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/generator" "^7.12.17"
+    "@babel/helper-function-name" "^7.12.13"
+    "@babel/helper-split-export-declaration" "^7.12.13"
+    "@babel/parser" "^7.12.17"
+    "@babel/types" "^7.12.17"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
 "@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.12.1", "@babel/types@^7.12.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.9.5":
   version "7.12.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.6.tgz#ae0e55ef1cce1fbc881cd26f8234eb3e657edc96"
   integrity sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.13", "@babel/types@^7.12.17":
+  version "7.12.17"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.17.tgz#9d711eb807e0934c90b8b1ca0eb1f7230d150963"
+  integrity sha512-tNMDjcv/4DIcHxErTgwB9q2ZcYyN0sUfgGKUK/mm1FJK7Wz+KstoEekxrl/tBiNDgLK1HGi+sppj1An/1DR4fQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3354,6 +3354,14 @@
     "@types/node" "*"
     "@types/rdf-js" "*"
 
+"@types/node-fetch@^2.5.8":
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.8.tgz#e199c835d234c7eb0846f6618012e558544ee2fb"
+  integrity sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "14.14.13"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.13.tgz#9e425079799322113ae8477297ae6ef51b8e0cdf"
@@ -5752,7 +5760,7 @@ colors@^1.4.0:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -8185,6 +8193,15 @@ fork-ts-checker-webpack-plugin@4.1.6:
     semver "^5.6.0"
     tapable "^1.0.0"
     worker-rpc "^0.1.0"
+
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"


### PR DESCRIPTION
Added `transformRequest` option to client config. The function accepts `(data, headers)` and can return any valid request body. The default value is a function that converts plain objects to JSON and sets `Content-Type`, but does not modify the body or headers for any other type. This design is a simplified version of the same option in [axios](https://github.com/axios/axios/blob/b7e954eba3911874575ed241ec2ec38ff8af21bb/lib/defaults.js#L31-L55).

Also:
* Changed `ClientConfig` so that instances of the class have a more rigid structure than the initialization options.
* Got rid of `unknown` types for known types, because that's silly.