### PR TITLE
Attempt to demo issue with following redirects client side

### DIFF
--- a/src/environment/App/App.jsx
+++ b/src/environment/App/App.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /*
  * Copyright (c) 2021, salesforce.com, inc.
  * All rights reserved.
@@ -7,16 +8,60 @@
 
 /* eslint-disable react/require-default-props */
 // eslint-disable-next-line no-use-before-define
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {ShopperCustomers, ShopperSearch} from 'lib';
+import { ShopperLogin, ShopperSearch } from 'lib';
 import config from '../config';
 import './App.css';
 
-const customerClient = new ShopperCustomers(config);
+// For this client, we want to explicitly handle redirects.
+const loginClient = new ShopperLogin({
+  fetchOptions: { redirect: 'manual' },
+  ...config
+})
 const searchClient = new ShopperSearch(config);
 
-const Product = ({id = '', name = '', price = 0, currency = ''}) => (
+
+// PKCE Helpers ---------------------------------------------------------------
+
+function generateRandomString(length) {
+  let randomString = ""
+  const possible =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+  for (let i = 0; i < length; i++) {
+    randomString += possible.charAt(
+      Math.floor(Math.random() * possible.length)
+    )
+  }
+  return randomString
+}
+
+function _arrayBufferToBase64(buffer) {
+  var binary = '';
+  var bytes = new Uint8Array(buffer);
+  var len = bytes.byteLength;
+  for (var i = 0; i < len; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return window.btoa(binary);
+}
+
+async function generateCodeChallenge(codeVerifier) {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(codeVerifier)
+  const digest = await window.crypto.subtle.digest('SHA-256', data)
+  const base64Digest = _arrayBufferToBase64(digest)
+  return base64Digest
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "")
+}
+
+const createCodeVerifier = () => generateRandomString(128)
+
+// App ------------------------------------------------------------------------
+
+const Product = ({ id = '', name = '', price = 0, currency = '' }) => (
   <div className="product-component">
     <h3>{name}</h3>
     <p className="product-price">
@@ -48,49 +93,98 @@ class App extends Component {
   }
 
   async componentDidMount() {
-    const {searchText} = this.state;
+    const { searchText } = this.state;
     this.doSearch(searchText);
   }
 
   handleChange(event) {
-    this.setState({searchText: event.target.value});
+    this.setState({ searchText: event.target.value });
   }
 
   handleSubmit(event) {
-    const {searchText} = this.state;
+    const { searchText } = this.state;
     this.doSearch(searchText);
     event.preventDefault();
   }
 
   async getSearchResults(text) {
     await this.getToken();
-    const {token} = this.state;
+    const { token } = this.state;
     this.searchClient.clientConfig.headers.authorization = token;
     return searchClient.productSearch({
-      parameters: {q: text},
+      parameters: { q: text },
     });
   }
 
   async getToken() {
-    const authResponse = await customerClient.authorizeCustomer(
-      {body: {type: 'guest'}},
-      true
-    );
-    this.state.token = authResponse.headers.get('authorization');
+    const code_verifier = createCodeVerifier()
+    const code_challenge = await generateCodeChallenge(code_verifier)
+    // We provide a URI here, but don't expect it to be called as we explicitly said we want to handle redirects
+    // ourselves above.
+    const redirect_uri = `https://localhost:3000/callback`
+    const client_id = config.parameters.clientId
+
+    const authorizeOptions = {
+      headers: {
+        "Content-Type": 'application/x-www-form-urlencoded',
+      },
+      parameters: {
+        client_id,
+        code_challenge,
+        hint: "guest",
+        redirect_uri,
+        response_type: "code",
+      },
+    }
+
+    const authorizeResponse =
+      await loginClient.authorizeCustomer(
+        authorizeOptions,
+        true
+      )
+
+    // We expect this the response to not be redirected, but it is :S
+
+    // const { usid, code } = Object.fromEntries(
+    //   new URL(authorizeResponse.headers.get("location")).searchParams
+    // )
+
+    const { usid, code } = Object.fromEntries(
+      new URL(authorizeResponse.url).searchParams
+    )
+    const tokenOptions = {
+      headers: {
+        "Content-Type": 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        client_id,
+        code_verifier,
+        code,
+        grant_type: "authorization_code_pkce",
+        redirect_uri,
+        usid,
+      }),
+    }
+    const tokenResponse = await loginClient.getAccessToken(
+      tokenOptions
+    )
+    
+    const { access_token } = tokenResponse
+    this.state.token = `Bearer ${access_token}`
   }
 
   async doSearch() {
-    const {searchText} = this.state;
+    const { searchText } = this.state;
     const results = await this.getSearchResults(searchText);
-    if (results?.hits[0]) {
-      this.setState({...results.hits[0]});
+    if (results.hits?.length) {
+      this.setState({ ...results.hits[0] });
     } else {
-      this.setState({productId: null});
+      this.setState({ productId: null });
     }
   }
 
   render() {
-    const {searchTerm, currency, productId, productName, price} = this.state;
+    const { searchTerm, currency, productId, productName, price } = this.state;
     return (
       <div className="search-component">
         <form className="search-bar" onSubmit={this.handleSubmit}>


### PR DESCRIPTION
Hey friends,

In https://github.com/salesforceCommerceCloud/pwa-kit, we've been trying to reduce the # of requests made to render any page to improve performance.

In https://github.com/SalesforceCommerceCloud/pwa-kit/pull/254, I'm trying to skip an extra request made in the context of a SLAS login.

The extra request I'm trying to skip is due `fetch`'s default behaviour of following redirect chains.

I'd like to use the `fetchOptions` of `ClientConfig` with the `ShopperLogin` client to disable following redirects:

```js
// This client shouldn't follow redirects.
const loginClient = new ShopperLogin({
  fetchOptions: { redirect: 'manual' },
  ...config
})
```

I've observed that redirects are not followed in Node.js environments, but are in the browser.

This PR demonstrates the issue.