### PR TITLE
Type check all TypeScript files and lint most of them, too.

### DIFF
--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -1,6 +1,7 @@
 ignores:
   # Include an explanation why the package is ignored
   - "@babel/*" # Used in babel.config.js and babel.config.jest.js
+  - "@types/react-dom" # Used in src/index.jsx
   - jest-environment-jsdom-sixteen # Used by test:react script in package.json
   - lib # Used in App.jsx, references local directory
   - node-fetch # False positive - clientConfig.ts imports the type from @types/node-fetch

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,7 @@
     "extends": [
         "plugin:react/recommended",
         "airbnb",
+        "plugin:@typescript-eslint/recommended",
         "prettier"
     ],
     "parser": "@typescript-eslint/parser",
@@ -27,6 +28,7 @@
     ],
     "reportUnusedDisableDirectives": true,
     "rules": {
+      "@typescript-eslint/explicit-module-boundary-types": "off",
       "import/extensions": ["error", "ignorePackages", {
         "js": "never",
         "jsx": "never",
@@ -73,6 +75,21 @@
         ],
         "rules": {
           "prettier/prettier": "off"
+        }
+      },
+      {
+        "files": [
+          "*.ts",
+          "*.tsx"
+        ],
+        "parserOptions": {
+          "project": ["./tsconfig.json"]
+        },
+        "extends": [
+          "plugin:@typescript-eslint/recommended-requiring-type-checking"
+        ],
+        "rules": {
+          "@typescript-eslint/explicit-module-boundary-types": "error"
         }
       }
     ],

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+/* eslint-disable @typescript-eslint/no-var-requires */
 const jest = require('./babel.config.jest');
 const pkg = require('./package.json');
 

--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
     "fix:style": "yarn run lint:style -- --fix",
     "lint": "eslint --ext js,jsx,ts,tsx .",
     "lint:style": "stylelint ./src/",
-    "renderTemplates": "ts-node --compiler-options '{\"module\": \"commonjs\", \"target\": \"ES6\" }' generate.ts",
+    "renderTemplates": "ts-node --compiler-options '{\"module\": \"commonjs\", \"target\": \"ES6\" }' ./scripts/generate.ts",
     "start": "HTTPS=true react-scripts start",
     "pretest": "yarn run lint && yarn run lint:style && depcheck && yarn run check:size",
     "test": "yarn run check:types && yarn run test:unit && CI=true yarn run test:react",
     "test:react": "react-scripts test --env=jest-environment-jsdom-sixteen src/environment",
     "test:unit": "jest --coverage --testPathIgnorePatterns node_modules src/environment --silent",
-    "updateApis": "ts-node --compiler-options '{\"module\": \"commonjs\", \"target\": \"ES6\" }' updateApis.ts && yarn diffApis"
+    "updateApis": "ts-node --compiler-options '{\"module\": \"commonjs\", \"target\": \"ES6\" }' ./scripts/updateApis.ts && yarn diffApis"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "collectCoverageFrom": [
       "src/static/**/*.{js,jsx,ts,tsx}",
       "scripts/**/*.{js,jsx,ts,tsx}",
+      "!scripts/generate.ts",
+      "!scripts/updateApis.ts",
       "!<rootDir>/node_modules/"
     ],
     "coverageReporters": [
@@ -101,7 +103,9 @@
     "@testing-library/jest-dom": "5.15.0",
     "@testing-library/react": "10.4.9",
     "@types/fs-extra": "^9.0.13",
+    "@types/handlebars-helpers": "^0.5.3",
     "@types/node-fetch": "^2.5.12",
+    "@types/react-dom": "^16.9.14",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "autoprefixer": "9.8.8",

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -1,31 +1,30 @@
 /*
- * Copyright (c) 2020, salesforce.com, inc.
+ * Copyright (c) 2021, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+/* eslint-disable no-console */
 import path from 'path';
 
 import {copySync} from 'fs-extra';
-import {generate} from '@commerce-apps/raml-toolkit';
 
-import {registerHelpers, registerPartials, setupApis} from './scripts/utils';
+import {registerHelpers, registerPartials, setupApis} from './utils';
 
 const API_DIRECTORY = process.env.COMMERCE_SDK_INPUT_DIR
   ? path.resolve(process.env.COMMERCE_SDK_INPUT_DIR)
-  : path.join(__dirname, 'apis');
-const OUTPUT_DIRECTORY = path.join(__dirname, 'src/lib');
-const STATIC_DIRECTORY = path.join(__dirname, 'src/static');
+  : path.join(__dirname, '../apis');
+const OUTPUT_DIRECTORY = path.join(__dirname, '../src/lib');
+const STATIC_DIRECTORY = path.join(__dirname, '../src/static');
 
 registerHelpers();
 registerPartials();
 
-// eslint-disable-next-line no-console
 console.log(`Creating SDK for ${API_DIRECTORY}`);
 
 const skipTestFiles = (src: string): boolean => !/\.test\.[a-z]+$/.test(src);
 copySync(STATIC_DIRECTORY, OUTPUT_DIRECTORY, {filter: skipTestFiles});
 
-setupApis(API_DIRECTORY, OUTPUT_DIRECTORY).then((apis: generate.ApiMetadata) =>
-  apis.render()
-);
+setupApis(API_DIRECTORY, OUTPUT_DIRECTORY)
+  .then(apis => apis.render())
+  .catch(console.error);

--- a/scripts/templateHelpers.test.ts
+++ b/scripts/templateHelpers.test.ts
@@ -47,16 +47,16 @@ describe('When adding namespaces to individual content (types)', () => {
     expect(addNamespace('object', 'types')).toStrictEqual('object');
   });
 
-  it('Throws an error when called with undfined content', () => {
-    expect(() => addNamespace(null, 'types')).toThrow('Invalid content');
-  });
-
-  it('Throws an error when called with null content', () => {
-    expect(() => addNamespace(undefined, 'types')).toThrow('Invalid content');
+  it('Throws an error when content is not a string', () => {
+    // The type assertion is required to test the implementation when the types are violated
+    const content = null as unknown as string;
+    expect(() => addNamespace(content, 'types')).toThrow('Invalid content');
   });
 
   it('Throws an error when the type is not a valid string', () => {
-    expect(() => addNamespace('Foo', null)).toThrow('Invalid namespace');
+    // The type assertion is required to test the implementation when the types are violated
+    const namespace = null as unknown as string;
+    expect(() => addNamespace('Foo', namespace)).toThrow('Invalid namespace');
   });
 
   it('Throws an error when the type is empty string', () => {
@@ -78,11 +78,15 @@ describe('When adding namespaces to elements in a complex content (an array)', (
   });
 
   it('Throws an error when the array is empty', () => {
-    expect(() => addNamespace('Array<>', null)).toThrow();
+    expect(() => addNamespace('Array<>', 'types')).toThrow(
+      'Array type has no content'
+    );
   });
 
   it('Throws an error when adding a type to an empty array element', () => {
-    expect(() => addNamespace('Array<Foo | | Baa>', null)).toThrow();
+    expect(() => addNamespace('Array<Foo | | Baa>', 'types')).toThrow(
+      'Empty type found'
+    );
   });
 });
 

--- a/scripts/templateHelpers.ts
+++ b/scripts/templateHelpers.ts
@@ -18,7 +18,7 @@ import {ASSET_OBJECT_MAP} from './config';
  * @param namespace - to be prefixed to types
  * @returns the content prefixed with the namespace
  */
-export function addNamespace(content: string, namespace: any): string {
+export function addNamespace(content: string, namespace: string): string {
   // Not handling invalid content.
   if (!content) {
     throw new Error('Invalid content');
@@ -29,9 +29,12 @@ export function addNamespace(content: string, namespace: any): string {
   }
 
   // if the content is an array, extract all of the elements
-  const matched = content.match(/^Array<(.*?)>$/);
-  const arrayType = !!matched;
-  const types = matched?.[1] || content;
+  const matched = /^Array<(.*?)>$/.exec(content);
+  if (matched && !matched[1]) {
+    throw new Error(`Array type has no content.`);
+  }
+  const isArrayType = !!matched;
+  const types = matched ? matched[1] : content;
 
   // Get a handle on individual types
   const typesToProcess = types.split('|');
@@ -59,7 +62,7 @@ export function addNamespace(content: string, namespace: any): string {
   const processedTypes = namespaceTypes.join(' | ');
 
   // Re-add Array if required
-  if (arrayType) {
+  if (isArrayType) {
     return `Array<${processedTypes}>`;
   }
   return processedTypes;

--- a/scripts/updateApis.ts
+++ b/scripts/updateApis.ts
@@ -7,13 +7,13 @@
 
 import path from 'path';
 import fs from 'fs-extra';
-import {updateApis} from './scripts/utils';
-import {ASSET_OBJECT_MAP} from './scripts/config';
+import {updateApis} from './utils';
+import {ASSET_OBJECT_MAP} from './config';
 
 const API_NAMES = Object.keys(ASSET_OBJECT_MAP);
 
-const OLD_APIS_PATH = path.join(__dirname, 'temp/oldApis');
-const PRODUCTION_API_PATH = path.join(__dirname, 'apis');
+const OLD_APIS_PATH = path.join(__dirname, '../temp/oldApis');
+const PRODUCTION_API_PATH = path.join(__dirname, '../apis');
 
 // DOWNLOAD PRODUCTION DATA
 fs.moveSync(PRODUCTION_API_PATH, OLD_APIS_PATH, {overwrite: true});

--- a/scripts/utils.test.ts
+++ b/scripts/utils.test.ts
@@ -14,7 +14,8 @@ import {
 
 const Handlebars = generate.HandlebarsWithAmfHelpers;
 const API_DIRECTORY = `${__dirname}/../apis`;
-const pkg = require('../package.json');
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
+const pkg: {version: string} = require('../package.json');
 
 describe('registerHelper', () => {
   it('registers our custom helpers', () => {

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {generate, download} from '@commerce-apps/raml-toolkit';
+import addHelpers from 'handlebars-helpers';
 import path from 'path';
 import {readJsonSync} from 'fs-extra';
 
@@ -20,13 +21,12 @@ type ApiMetadata = generate.ApiMetadata;
 // -------HELPER REGISTRATION-------
 const Handlebars = generate.HandlebarsWithAmfHelpers;
 
-require('handlebars-helpers')({handlebars: Handlebars});
+addHelpers({handlebars: Handlebars});
 
 /**
  * Register the custom helpers defined in our pipeline
  */
 export function registerHelpers(): void {
-  // eslint-disable-next-line no-undef
   const helpers: {[key: string]: Handlebars.HelperDelegate} = templateHelpers;
   const keys: string[] = Object.keys(helpers);
   keys.forEach(helper => Handlebars.registerHelper(helper, helpers[helper]));
@@ -82,6 +82,7 @@ export async function setupApis(
   let apis = loadApiDirectory(inputDir);
   // SDK version is not API metadata, so it is not included in the file, but it
   // is necessary for generating the SDK (as part of the user agent header).
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   apis.metadata.sdkVersion = await readJsonSync(PACKAGE_JSON).version;
   await apis.init();
 

--- a/src/static/clientConfig.test.ts
+++ b/src/static/clientConfig.test.ts
@@ -4,25 +4,27 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import {BaseUriParameters} from 'lib/helpers';
 import ClientConfig, {ClientConfigInit} from './clientConfig';
 
 describe('ClientConfig constructor', () => {
   test('will throw if missing shortCode parameter', () => {
     // Type assertion is necessary because we're violating the type to test the implementation
-    expect(() => new ClientConfig({} as ClientConfigInit<any>)).toThrow(
-      'Missing required parameter: shortCode'
-    );
+    expect(
+      () => new ClientConfig({} as ClientConfigInit<BaseUriParameters>)
+    ).toThrow('Missing required parameter: shortCode');
   });
 
   test('creates an instance from an init object', () => {
+    const parameters = {param: 'param', shortCode: 'shortCode'};
     // `init` is Required<> to ensure that all init options are tested
-    const init: Required<ClientConfigInit<any>> = {
+    const init: Required<ClientConfigInit<typeof parameters>> = {
       baseUri: 'https://example.com',
       fetchOptions: {keepalive: false},
       headers: {authorization: 'token'},
-      parameters: {param: 'param', shortCode: 'shortCode'},
+      parameters,
       proxy: 'https://proxy.com',
-      transformRequest: v => v,
+      transformRequest: ClientConfig.defaults.transformRequest,
     };
     expect(new ClientConfig(init)).toEqual({...init});
   });

--- a/src/static/helpers.ts
+++ b/src/static/helpers.ts
@@ -6,13 +6,13 @@
  */
 
 export type CompositeParameters<
-  MethodParameters extends object,
-  ConfigParameters extends object
+  MethodParameters extends Record<string, unknown>,
+  ConfigParameters extends Record<string, unknown>
 > = Omit<MethodParameters, keyof ConfigParameters> & Partial<MethodParameters>;
 
 export type RequireParametersUnlessAllAreOptional<
-  T extends {parameters?: object}
-> = {} extends NonNullable<T['parameters']>
+  T extends {parameters?: Record<string, unknown>}
+> = Record<string, never> extends NonNullable<T['parameters']>
   ? T
   : T & Required<Pick<T, 'parameters'>>;
 

--- a/src/static/templateUrl.ts
+++ b/src/static/templateUrl.ts
@@ -13,7 +13,7 @@ export default class TemplateURL extends URL {
    */
   constructor(
     url: string,
-    base?: string,
+    base: string,
     parameters?: {
       pathParams?: PathParameters;
       queryParams?: QueryParameters;
@@ -39,7 +39,7 @@ export default class TemplateURL extends URL {
    *
    * @param newOriginString - The new origin to substitute (ex: https://example.com)
    */
-  replaceOrigin(newOriginString: string) {
+  replaceOrigin(newOriginString: string): void {
     const newOriginUrl = new URL(newOriginString);
     this.protocol = newOriginUrl.protocol;
     this.host = newOriginUrl.host;
@@ -84,7 +84,7 @@ export default class TemplateURL extends URL {
     return parameters
       ? template.replace(
           /\{([^\}]+)\}/g /* eslint-disable-line no-useless-escape */,
-          (match, param) => String(parameters[param])
+          (match, param: string) => String(parameters[param])
         )
       : template;
   }

--- a/src/test/crossFetchNode.test.ts
+++ b/src/test/crossFetchNode.test.ts
@@ -6,6 +6,7 @@
  */
 
 import nock from 'nock';
+import {FetchOptions} from '../static/clientConfig';
 import {ClientConfigInit, ShopperCustomers, ShopperSearch} from '../lib';
 import config from '../environment/config';
 
@@ -21,9 +22,7 @@ type TestConfigParameters = typeof config.parameters;
 const customerClient = new ShopperCustomers(config);
 const searchClient = new ShopperSearch(config);
 
-beforeEach(async () => {
-  nock.cleanAll();
-});
+beforeEach(() => nock.cleanAll());
 
 test('test getting a token with a post operation', async () => {
   nock('https://localhost:3000')
@@ -50,7 +49,7 @@ test('test getting a token with a post operation', async () => {
     true
   );
   // Get the authorization token and validate it is correct
-  const token = await authResponse.headers.get('authorization');
+  const token = authResponse.headers.get('authorization');
   expect(token).toEqual('Bearer test-auth');
 });
 
@@ -83,7 +82,7 @@ test('test getting a token without a proxy', async () => {
     true
   );
   // Get the authorization token and validate it is correct
-  const token = await authResponse.headers.get('authorization');
+  const token = authResponse.headers.get('authorization');
   expect(token).toEqual('Bearer test-auth');
 });
 
@@ -264,7 +263,7 @@ test('should not fail when arbitrary parameters are configured in fetchOptions',
     fetchOptions: {
       somekey: 'some value',
       timeout: 1000,
-    } as any, // Type assertion required because we are deliberately violating the type
+    } as FetchOptions, // Type assertion required because we are deliberately violating the type
   };
 
   const client = new ShopperSearch(clientConfig);

--- a/src/test/parameters.test.ts
+++ b/src/test/parameters.test.ts
@@ -124,7 +124,7 @@ describe('Parameters', () => {
     expect(response).toEqual(MOCK_RESPONSE);
   });
 
-  it('will throw if a required parameter is missing', () => {
+  it('will throw if a required parameter is missing', async () => {
     nock.cleanAll(); // Not needed for this test
 
     const customersClient = new ShopperCustomers({
@@ -135,7 +135,8 @@ describe('Parameters', () => {
     });
 
     // Type assertion is used because we're violating the type to test the implementation
-    expect(customersClient.authorizeCustomer({} as any)).rejects.toEqual(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(customersClient.authorizeCustomer({} as any)).rejects.toEqual(
       new Error('Missing required path parameter: organizationId')
     );
   });

--- a/templates/client.ts.hbs
+++ b/templates/client.ts.hbs
@@ -88,15 +88,16 @@ export type {{name.upperCamelCase}}Parameters = {{name.upperCamelCase}}PathParam
 
 */
 export class {{name.upperCamelCase}}<ConfigParameters extends {{{name.upperCamelCase}}}Parameters & Record<string, unknown>> {
-  public clientConfig: ClientConfig<ConfigParameters>;
+  // baseUri is not required on ClientConfig, but we know that we provide one in the class constructor
+  public clientConfig: ClientConfig<ConfigParameters> & { baseUri: string };
 
   static readonly defaultBaseUri = "{{getBaseUriFromDocument model}}";
 
   constructor(config: ClientConfigInit<ConfigParameters>) {
-    this.clientConfig = new ClientConfig({
-      baseUri: new.target.defaultBaseUri,
-      ...config
-    });
+    const cfg = {...config}
+    if (!cfg.baseUri) cfg.baseUri = new.target.defaultBaseUri;
+    // Type assertion is safe because ^^^
+    this.clientConfig = new ClientConfig(cfg) as ClientConfig<ConfigParameters> & { baseUri: string };
   }
 
   {{> operationsPartial model}}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": [
-    "src"
+    "src",
+    "scripts"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4996,6 +4996,13 @@
   resolved "https://registry.yarnpkg.com/@types/graphlib/-/graphlib-2.1.7.tgz#e6a47a4f43511f5bad30058a669ce5ce93bfd823"
   integrity sha512-K7T1n6U2HbTYu+SFHlBjz/RH74OA2D/zF1qlzn8uXbvB4uRg7knOM85ugS2bbXI1TXMh7rLqk4OVRwIwEBaixg==
 
+"@types/handlebars-helpers@^0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@types/handlebars-helpers/-/handlebars-helpers-0.5.3.tgz#5ff8da505867e1962c964cb50b15f83f948bde4f"
+  integrity sha512-h+a3eIWts6BgqzlmlmCH6K7yvCfbcEm5Gs+6CMYwbAi8SgC3I/+HEPEciDVT7qav+6BPE0M0nB2UhnwRYkO68w==
+  dependencies:
+    handlebars ">=4.1.0"
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
@@ -5208,6 +5215,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.5.tgz#b6ab3bba29e16b821d84e09ecfaded462b816b00"
   integrity sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==
 
+"@types/prop-types@*":
+  version "15.7.4"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
+  integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
+
 "@types/q@^1.5.1":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
@@ -5219,6 +5231,22 @@
   integrity sha512-2uaR7ks0380MqzUWGOPOOk9yZIr/6MOaCcaj3ntKgd2PqNocgi8j5kSHIJTDe+5ABtTHqKMSE0v0UqrsT8ibgQ==
   dependencies:
     "@types/node" "*"
+
+"@types/react-dom@^16.9.14":
+  version "16.9.14"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.14.tgz#674b8f116645fe5266b40b525777fc6bb8eb3bcd"
+  integrity sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==
+  dependencies:
+    "@types/react" "^16"
+
+"@types/react@^16":
+  version "16.14.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.21.tgz#35199b21a278355ec7a3c40003bd6a334bd4ae4a"
+  integrity sha512-rY4DzPKK/4aohyWiDRHS2fotN5rhBSK6/rz1X37KzNna9HJyqtaGAbq9fVttrEPWF5ywpfIP1ITL8Xi2QZn6Eg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
 
 "@types/resolve@0.0.8":
   version "0.0.8"
@@ -5245,6 +5273,11 @@
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@types/sarif/-/sarif-2.1.3.tgz#1f9c16033f1461536ac014284920350109614c02"
   integrity sha512-zf+EoIplTkQW2TV2mwtJtlI0g540Z3Rs9tX9JqRAtyjnDCqkP+eMTgWCj3PGNbQpi+WXAjvC3Ou/dvvX2sLK4w==
+
+"@types/scheduler@*":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
+  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@types/semver@^7.3.6":
   version "7.3.8"
@@ -8545,6 +8578,11 @@ cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
+csstype@^3.0.2:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
+  integrity sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
+
 curriable@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/curriable/-/curriable-1.3.0.tgz#cb054bc7bbc1f440cbc613527b8a05b57e19e1ab"
@@ -11075,7 +11113,7 @@ handlebars-utils@^1.0.2, handlebars-utils@^1.0.4, handlebars-utils@^1.0.6:
     kind-of "^6.0.0"
     typeof-article "^0.1.1"
 
-handlebars@4.7.7:
+handlebars@4.7.7, handlebars@>=4.1.0:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==


### PR DESCRIPTION
Because of an issue that came up in #63, I wanted to enable [`@typescript-eslint/no-floating-promises`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-floating-promises.md). Turns out that took a bit of work. Only code change of substance is in the template helpers.