### PR TITLE
Release v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v1.5.2
+
+### New Features
+
+* If the `throwOnBadResponse` flag is set, the error thrown now includes the full HTTP response object.
+
+### Bug Fixes
+
+* An error about invalid user-agent is no longer printed to console when making requests in a browser.
+
 ## v1.5.1
 
 #### Documentation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commerce-sdk-isomorphic",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": false,
   "description": "Salesforce Commerce SDK Isomorphic",
   "bugs": {


### PR DESCRIPTION
# CHANGELOG

## v1.5.2

### New Features

* If the `throwOnBadResponse` flag is set, the error thrown now includes the full HTTP response object.

### Bug Fixes

* An error about invalid user-agent is no longer printed to console when making requests in a browser.
