### PR TITLE
 loginRegisteredUserB2C method to not request redirect_uri

### DIFF
--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -241,9 +241,17 @@ export async function loginRegisteredUserB2C(
     },
   };
 
-  const response = await slasClientCopy.authenticateCustomer(options, true);
+  const response = await slasClientCopy
+    .authenticateCustomer(options, true)
+    .catch((error: Error) => {
+      throw new Error(
+        `authenticateCustomer function failed because of ${error.message}`
+      );
+    });
 
-  const authResponse = getCodeAndUsidFromUrl(response.url);
+  const redirectUrl = response.headers?.get('location') || response.url;
+
+  const authResponse = getCodeAndUsidFromUrl(redirectUrl);
 
   const tokenBody = {
     client_id: slasClient.clientConfig.parameters.clientId,

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -218,7 +218,7 @@ export async function loginRegisteredUserB2C(
   // follow setting allows us to get the url.
   slasClientCopy.clientConfig.fetchOptions = {
     ...slasClient.clientConfig.fetchOptions,
-    redirect: onClient ? 'follow' : 'manual',
+    redirect: isBrowser ? 'follow' : 'manual',
   };
 
   const authorization = `Basic ${stringToBase64(

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -210,6 +210,17 @@ export async function loginRegisteredUserB2C(
   const codeVerifier = createCodeVerifier();
   const codeChallenge = await generateCodeChallenge(codeVerifier);
 
+  // Create a copy to override specific fetchOptions
+  const slasClientCopy = new ShopperLogin(slasClient.clientConfig);
+
+  // set manual redirect on server since node allows access to the location
+  // header and it skips the extra call. In the browser, only the default
+  // follow setting allows us to get the url.
+  slasClientCopy.clientConfig.fetchOptions = {
+    ...slasClient.clientConfig.fetchOptions,
+    redirect: onClient ? 'follow' : 'manual',
+  };
+
   const authorization = `Basic ${stringToBase64(
     `${credentials.username}:${credentials.password}`
   )}`;
@@ -230,7 +241,7 @@ export async function loginRegisteredUserB2C(
     },
   };
 
-  const response = await slasClient.authenticateCustomer(options, true);
+  const response = await slasClientCopy.authenticateCustomer(options, true);
 
   const authResponse = getCodeAndUsidFromUrl(response.url);
 

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -112,6 +112,7 @@ export async function authorize(
   // set manual redirect on server since node allows access to the location
   // header and it skips the extra call. In the browser, only the default
   // follow setting allows us to get the url.
+  /* istanbul ignore next */
   slasClientCopy.clientConfig.fetchOptions = {
     ...slasClient.clientConfig.fetchOptions,
     redirect: isBrowser ? 'follow' : 'manual',
@@ -217,6 +218,7 @@ export async function loginRegisteredUserB2C(
   // set manual redirect on server since node allows access to the location
   // header and it skips the extra call. In the browser, only the default
   // follow setting allows us to get the url.
+  /* istanbul ignore next */
   slasClientCopy.clientConfig.fetchOptions = {
     ...slasClient.clientConfig.fetchOptions,
     redirect: isBrowser ? 'follow' : 'manual',
@@ -245,11 +247,6 @@ export async function loginRegisteredUserB2C(
   const response = await slasClientCopy
     .authenticateCustomer(options, true)
     .catch((error: Error) => {
-      if (error instanceof ResponseError) {
-        throw new Error(
-          `Error in authenticateCustomer: ${error.message} in response: ${JSON.stringify(error.response)}`
-        );
-      }
       throw new Error(`Error in authenticateCustomer: ${error.message}`);
     });
 

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -7,7 +7,6 @@
 
 import {nanoid} from 'nanoid';
 
-import ResponseError from 'lib/responseError';
 import {isBrowser} from './environment';
 
 import {
@@ -15,6 +14,7 @@ import {
   TokenRequest,
   TokenResponse,
 } from '../../lib/shopperLogin';
+import ResponseError from '../responseError';
 
 export const stringToBase64 = isBrowser
   ? btoa
@@ -244,11 +244,12 @@ export async function loginRegisteredUserB2C(
     },
   };
 
-  const response = await slasClientCopy
-    .authenticateCustomer(options, true)
-    .catch((error: Error) => {
-      throw new Error(`Error in authenticateCustomer: ${error.message}`);
-    });
+  const response = await slasClientCopy.authenticateCustomer(options, true);
+
+  // Possible statuses: 303 (success), 400, 401, 500
+  if (response.status !== 303) {
+    throw new ResponseError(response);
+  }
 
   const redirectUrl = response.headers?.get('location') || response.url;
 

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -7,6 +7,7 @@
 
 import {nanoid} from 'nanoid';
 
+import ResponseError from 'lib/responseError';
 import {isBrowser} from './environment';
 
 import {
@@ -244,9 +245,12 @@ export async function loginRegisteredUserB2C(
   const response = await slasClientCopy
     .authenticateCustomer(options, true)
     .catch((error: Error) => {
-      throw new Error(
-        `authenticateCustomer function failed because of ${error.message}`
-      );
+      if (error instanceof ResponseError) {
+        throw new Error(
+          `Error in authenticateCustomer: ${error.message} in response: ${JSON.stringify(error.response)}`
+        );
+      }
+      throw new Error(`Error in authenticateCustomer: ${error.message}`);
     });
 
   const redirectUrl = response.headers?.get('location') || response.url;


### PR DESCRIPTION
As a developer using the isomorphic SDK, I would like the loginRegisteredUserB2C method to not request redirect_uri when running server-side so that my code does not fail if there is not a valid server running on redirect_uri.

AC:

Request is made with manual redirect
Errors are handled in loginRegisteredUserB2C() and the other helpers