### PR TITLE
Added a test to check the urlencoded body transition

### DIFF
--- a/src/test/requests.test.ts
+++ b/src/test/requests.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import nock from 'nock';
+import {ShopperLogin} from '../lib';
+import ClientConfig from '../static/clientConfig';
+
+const config: ClientConfig<any> = {
+  baseUri: 'https://SHORT_CODE.api.commercecloud.salesforce.com/shopper/auth/v1',
+  fetchOptions: {keepalive: false},
+  headers: {authorization: 'token'},
+  parameters: {
+    shortCode: 'SHORT_CODE',
+    organizationId: 'ORGANIZATION_ID',
+    siteId: 'SITE_ID',
+    clientId: 'CLIENT_ID',
+  },
+  transformRequest: ClientConfig.defaults.transformRequest,
+  throwOnBadResponse: false
+};
+
+describe('Requests with body', () => {
+  beforeEach(nock.cleanAll);
+
+  it('sends correct media type for urlencoded endpoints', async () => {
+    const body = {
+      token: 'TOKEN',
+      token_type_hint: 'REFRESH_TOKEN',
+    };
+    const scope = nock('https://SHORT_CODE.api.commercecloud.salesforce.com/shopper/auth/v1', {
+      reqheaders: {"content-type": 'application/x-www-form-urlencoded'
+      }
+    })
+      .filteringRequestBody(innerBody => {
+        // Putting the assertion here isn't ideal, but it's the only place I can find that nock
+        // exposes the raw contents of the request body. (The body provided to `.post` has already
+        // been parsed to an object, so we can't use that to detect the type.)
+        expect(innerBody).toEqual('token=TOKEN&token_type_hint=REFRESH_TOKEN');
+        console.log(innerBody);
+        return innerBody;
+      })
+      .post(
+        '/organizations/ORGANIZATION_ID/oauth2/revoke',
+        body
+      )
+      .reply(200);
+
+    const client = new ShopperLogin(config);
+    const result = await client.revokeToken({body});
+    expect(scope.isDone()).toBe(true);
+  });
+});


### PR DESCRIPTION
The story seems to be already implemented by @wjhsf a couple of months ago with these lines in operations.ts.hbs: 
`      const headers: Record<string, string> = {
        {{#if (isRequestWithPayload request)}}
        "Content-Type": "{{{getMediaTypeFromRequest request}}}",
        {{/if}}
        ...this.clientConfig.headers,
        ...options?.headers
      };
`
In this PR I have added a test that checks if the content-type is urlencoded, the body should be urlencoded. 