### PR TITLE
Export namespaced type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
   "bundlesize": [
     {
       "path": "lib/**/*.js",
-      "maxSize": "100 kB"
+      "maxSize": "45 kB"
     },
     {
       "path": "commerce-sdk-isomorphic-with-deps.tgz",

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     },
     {
       "path": "commerce-sdk-isomorphic-with-deps.tgz",
-      "maxSize": "310 kB"
+      "maxSize": "315 kB"
     }
   ],
   "proxy": "https://SHORTCODE.api.commercecloud.salesforce.com"

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     },
     {
       "path": "commerce-sdk-isomorphic-with-deps.tgz",
-      "maxSize": "300 kB"
+      "maxSize": "410 kB"
     }
   ],
   "proxy": "https://SHORTCODE.api.commercecloud.salesforce.com"

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     },
     {
       "path": "commerce-sdk-isomorphic-with-deps.tgz",
-      "maxSize": "410 kB"
+      "maxSize": "300 kB"
     }
   ],
   "proxy": "https://SHORTCODE.api.commercecloud.salesforce.com"

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     },
     {
       "path": "commerce-sdk-isomorphic-with-deps.tgz",
-      "maxSize": "300 kB"
+      "maxSize": "310 kB"
     }
   ],
   "proxy": "https://SHORTCODE.api.commercecloud.salesforce.com"

--- a/src/static/clientConfig.ts
+++ b/src/static/clientConfig.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import type {RequestInit as NodeRequestInit} from 'node-fetch';
-import type {BaseUriParameters} from './helpers';
+import type {BaseUriParameters} from './helpers/types';
 
 /**
  * Alias for `RequestInit` from TypeScript's DOM lib, to more clearly differentiate

--- a/src/static/clientConfig.ts
+++ b/src/static/clientConfig.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import type {RequestInit as NodeRequestInit} from 'node-fetch';
-import {BaseUriParameters} from './helpers';
+import type {BaseUriParameters} from './helpers';
 
 /**
  * Alias for `RequestInit` from TypeScript's DOM lib, to more clearly differentiate

--- a/src/static/helpers/index.ts
+++ b/src/static/helpers/index.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+// This file should not be used for internal package imports.
+// Doing so may lead to circular dependencies or duplicate exports (due to rollup mangling the types)
 export * from './environment';
 export * from './slasHelper';
 export * from './types';

--- a/templates/index.ts.hbs
+++ b/templates/index.ts.hbs
@@ -4,7 +4,9 @@
 {{!-- Reason: The API specs contain duplicated type declarations. --}}
 {{!-- rollup=plugin-ts does de-duplication, so it's okay to have dups --}}
 // @ts-ignore
-export * from "./{{name.lowerCamelCase}}";
+export { {{name.upperCamelCase}} } from "./{{name.lowerCamelCase}}";
+import type * as {{name.upperCamelCase}}Types from "./{{name.lowerCamelCase}}";
+export {{name.upperCamelCase}}Types from "./{{name.lowerCamelCase}}";
 {{/each}}
 export type { ClientConfigInit } from "./clientConfig";
 // Can't currently use `export from` with default exports

--- a/templates/index.ts.hbs
+++ b/templates/index.ts.hbs
@@ -2,7 +2,7 @@
 {{!-- We intentionally added the @ts-ignore comment --}}
 {{!-- This comment is used to ignore the error ts-2308 specifically. --}}
 {{!-- Reason: The API specs contain duplicated type declarations. --}}
-{{!-- rollup=plugin-ts does actually de-dupe them, so it's okay to have dups --}}
+{{!-- rollup=plugin-ts does de-duplication, so it's okay to have dups --}}
 // @ts-ignore
 export * from "./{{name.lowerCamelCase}}";
 {{/each}}

--- a/templates/index.ts.hbs
+++ b/templates/index.ts.hbs
@@ -1,5 +1,5 @@
 {{#each children}}
-export * as {{name.upperCamelCase}} from "./{{name.lowerCamelCase}}";
+import * as {{name.upperCamelCase}} from "./{{name.lowerCamelCase}}";
 {{/each}}
 export type { ClientConfigInit } from "./clientConfig";
 // Can't currently use `export from` with default exports
@@ -9,3 +9,8 @@ export { ClientConfig, TemplateURL };
 
 import * as helpers from "./helpers";
 export { helpers };
+export default {
+{{#each children}}
+  ...{{name.upperCamelCase}},
+{{/each}}
+}

--- a/templates/index.ts.hbs
+++ b/templates/index.ts.hbs
@@ -1,5 +1,5 @@
 {{#each children}}
-export { {{name.upperCamelCase}} } from "./{{name.lowerCamelCase}}";
+export * as {{name.upperCamelCase}} from "./{{name.lowerCamelCase}}";
 {{/each}}
 export type { ClientConfigInit } from "./clientConfig";
 // Can't currently use `export from` with default exports

--- a/templates/index.ts.hbs
+++ b/templates/index.ts.hbs
@@ -1,12 +1,7 @@
 {{#each children}}
-{{!-- We intentionally added the @ts-ignore comment --}}
-{{!-- This comment is used to ignore the error ts-2308 specifically. --}}
-{{!-- Reason: The API specs contain duplicated type declarations. --}}
-{{!-- rollup=plugin-ts does de-duplication, so it's okay to have dups --}}
-// @ts-ignore
 export { {{name.upperCamelCase}} } from "./{{name.lowerCamelCase}}";
 import type * as {{name.upperCamelCase}}Types from "./{{name.lowerCamelCase}}";
-export {{name.upperCamelCase}}Types from "./{{name.lowerCamelCase}}";
+export type { {{name.upperCamelCase}}Types };
 {{/each}}
 export type { ClientConfigInit } from "./clientConfig";
 // Can't currently use `export from` with default exports

--- a/templates/index.ts.hbs
+++ b/templates/index.ts.hbs
@@ -1,5 +1,10 @@
 {{#each children}}
-import * as {{name.upperCamelCase}} from "./{{name.lowerCamelCase}}";
+{{!-- We intentionally added the @ts-ignore comment --}}
+{{!-- This comment is used to ignore the error ts-2308 specifically. --}}
+{{!-- Reason: The API specs contain duplicated type declarations. --}}
+{{!-- rollup=plugin-ts does actually de-dupe them, so it's okay to have dups --}}
+// @ts-ignore
+export * from "./{{name.lowerCamelCase}}";
 {{/each}}
 export type { ClientConfigInit } from "./clientConfig";
 // Can't currently use `export from` with default exports
@@ -9,8 +14,3 @@ export { ClientConfig, TemplateURL };
 
 import * as helpers from "./helpers";
 export { helpers };
-export default {
-{{#each children}}
-  ...{{name.upperCamelCase}},
-{{/each}}
-}


### PR DESCRIPTION
Hey team, as mentioned in https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/issues/93, the type declarations in this lib are not exported. I'm hoping that we could solve the issue in a minimal / non-breaking way, to unblock the pwa kit team's current React hook work.

# Root Cause

After some investigation, I realize the root issue that stops us from exporting the types is the source API RAML specifications contains duplicate type declarations and rollup won't build the lib with the typescript errors.

![Screen Shot 2022-07-13 at 9 38 13 AM](https://user-images.githubusercontent.com/10948652/178786087-d5a64dc0-59ee-4acf-86d5-3373b4d1fac7.png)

# Solution

Create specific types namespaces for each API and export them as `${API}Types`, e.g. `ShopperBasketsTypes`
