### PR TITLE
Bump the package size limit to 350kb

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     },
     {
       "path": "commerce-sdk-isomorphic-with-deps.tgz",
-      "maxSize": "315 kB"
+      "maxSize": "350 kB"
     }
   ],
   "proxy": "https://SHORTCODE.api.commercecloud.salesforce.com"


### PR DESCRIPTION
The CI is failing on main branch because the exceeded package size limit. (For some reason it didn't complaint on my branch. I'm guessing the dependencies versions are not locked so the result of each `npm install` gives different dependencies and in turn result in different build?)

<img width="1196" alt="Screen Shot 2022-07-14 at 1 59 56 PM" src="https://user-images.githubusercontent.com/10948652/179085946-274e2cc9-3790-4c56-9334-24d5bf377f45.png">

This PR bumps up the size to 350kb to have some room.

(I don't quite understand why we need a limit for the whole package. It makes sense to have the limit for JS but I don't think it matters for the rest of the files like type declarations, READMEs etc. 🤷 Shall we remove this test?)