### PR TITLE
W-11358406: Fix logout function in SLAS helpers

### DIFF
--- a/src/environment/App/App.spec.jsx
+++ b/src/environment/App/App.spec.jsx
@@ -22,7 +22,7 @@ describe('environment > App', () => {
     .get(`/shopper/auth/v1/organizations/${config.parameters.organizationId}/oauth2/authorize`)
     .query(true)
     .reply(
-      200,
+      303,
       {
         access_token: 'access_token'
       }


### PR DESCRIPTION
Small PR that fixes the `logout` function and updates the `authorize` function to use the `ResponseError` class for error handling.