### PR TITLE
Fix SLAS callback error handling

### DIFF
--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -168,14 +168,18 @@ describe('Authorize user', () => {
     expect(authResponse).toStrictEqual(expectedAuthResponse);
   });
 
-  test('throws error on non 303 response', async () => {
+  test('throws error on error response', async () => {
     const mockSlasClient = createMockSlasClient();
     const {shortCode, organizationId} = mockSlasClient.clientConfig.parameters;
 
     nock(`https://${shortCode}.api.commercecloud.salesforce.com`)
       .get(`/shopper/auth/v1/organizations/${organizationId}/oauth2/authorize`)
       .query(true)
-      .reply(400, {response_body: 'response_body'}, {location: ''});
+      .reply(303, undefined, {
+        Location: '/callback?error=invalid_request',
+      })
+      .get('/callback?error=invalid_request')
+      .reply(200);
 
     await expect(
       slasHelper.authorize(mockSlasClient, codeVerifier, parameters)

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -168,7 +168,7 @@ describe('Authorize user', () => {
     expect(authResponse).toStrictEqual(expectedAuthResponse);
   });
 
-  test('throws error on error response', async () => {
+  test('throws error on SLAS callback error response', async () => {
     const mockSlasClient = createMockSlasClient();
     const {shortCode, organizationId} = mockSlasClient.clientConfig.parameters;
 
@@ -185,6 +185,20 @@ describe('Authorize user', () => {
       slasHelper.authorize(mockSlasClient, codeVerifier, parameters)
     ).rejects.toThrow(ResponseError);
   });
+});
+
+test('throws error on 400 response', async () => {
+  const mockSlasClient = createMockSlasClient();
+  const {shortCode, organizationId} = mockSlasClient.clientConfig.parameters;
+
+  nock(`https://${shortCode}.api.commercecloud.salesforce.com`)
+    .get(`/shopper/auth/v1/organizations/${organizationId}/oauth2/authorize`)
+    .query(true)
+    .reply(400, {response_body: 'response_body'}, {location: ''});
+
+  await expect(
+    slasHelper.authorize(mockSlasClient, codeVerifier, parameters)
+  ).rejects.toThrow(ResponseError);
 });
 
 describe('Guest user flow', () => {

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -131,16 +131,18 @@ export async function authorize(
   };
 
   const response = await slasClientCopy.authorizeCustomer(options, true);
-  const redirectUrl = response.headers?.get('location') || response.url;
+  const redirectUrlString = response.headers?.get('location') || response.url;
+  const redirectUrl = new URL(redirectUrlString);
+  const searchParams = Object.fromEntries(redirectUrl.searchParams.entries());
 
   // url is a read only property we unfortunately cannot mock out using nock
   // meaning redirectUrl will not have a falsy value for unit tests
   /* istanbul ignore next */
-  if (response.status !== 303 || !redirectUrl) {
+  if (searchParams.error) {
     throw new ResponseError(response);
   }
 
-  return {url: redirectUrl, ...getCodeAndUsidFromUrl(redirectUrl)};
+  return {url: redirectUrlString, ...getCodeAndUsidFromUrl(redirectUrlString)};
 }
 
 /**
@@ -245,15 +247,15 @@ export async function loginRegisteredUserB2C(
   };
 
   const response = await slasClientCopy.authenticateCustomer(options, true);
+  const redirectUrlString = response.headers?.get('location') || response.url;
+  const redirectUrl = new URL(redirectUrlString);
+  const searchParams = Object.fromEntries(redirectUrl.searchParams.entries());
 
-  // Possible statuses: 303 (success), 400, 401, 500
-  if (response.status !== 303) {
+  if (searchParams.error) {
     throw new ResponseError(response);
   }
 
-  const redirectUrl = response.headers?.get('location') || response.url;
-
-  const authResponse = getCodeAndUsidFromUrl(redirectUrl);
+  const authResponse = getCodeAndUsidFromUrl(redirectUrlString);
 
   const tokenBody = {
     client_id: slasClient.clientConfig.parameters.clientId,

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -138,7 +138,7 @@ export async function authorize(
   // url is a read only property we unfortunately cannot mock out using nock
   // meaning redirectUrl will not have a falsy value for unit tests
   /* istanbul ignore next */
-  if (searchParams.error) {
+  if (response.status >= 400 || searchParams.error) {
     throw new ResponseError(response);
   }
 
@@ -251,7 +251,7 @@ export async function loginRegisteredUserB2C(
   const redirectUrl = new URL(redirectUrlString);
   const searchParams = Object.fromEntries(redirectUrl.searchParams.entries());
 
-  if (searchParams.error) {
+  if (response.status >= 400 || searchParams.error) {
     throw new ResponseError(response);
   }
 


### PR DESCRIPTION
Hey team,

I believe there is a bug with the SLAS helpers, specifically the ones that deals with redirect callbacks: `authorize` and `loginRegisteredUserB2C`.

Currently these two helpers will throw an error if the response status is not 303. However, on the browser environment, we always follow the redirect and by following the redirect, the response status will not be 303, but the response from the actual callback endpoint, which is likely a 200 or something. Screenshot below shows that the callback 200 causes the helpers to throw.

Problematic code:
```js
const response = await slasClientCopy.authenticateCustomer(options, true);

// when the redirect is followed on the browser, status will not be 303
// and the if statement will always evaluate to true and throws error
if (response.status !== 303) {
  throw new ResponseError(response);
}
```

![Screen Shot 2022-08-11 at 12 30 31 AM](https://user-images.githubusercontent.com/10948652/184084888-ed793fcb-bb8c-4bd4-9f4f-6be802ce0c04.png)

Secondly, there are two scenarios when we need to throw errors:
1. when SLAS API returns error, which the status code is >= 400.
2. when the redirect callback has an error query string `/callback?error=invalid_request` <- this is not handled!

The PR fixes the above two issues.

I've tested the solution on my PWA testing project and it seems the issue is gone with the changes in this PR.