### PR TITLE
Add channel_id to SLAS getAccessToken calls

### DIFF
--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -205,6 +205,7 @@ describe('Guest user flow', () => {
   const expectedTokenBody = {
     body: {
       client_id: 'client_id',
+      channel_id: 'site_id',
       code: 'J2lHm0cgXmnXpwDhjhLoyLJBoUAlBfxDY-AhjqGMC-o',
       code_verifier: expect.stringMatching(/./) as string,
       grant_type: 'authorization_code_pkce',
@@ -233,6 +234,7 @@ describe('Registered B2C user flow', () => {
   const expectedTokenBody = {
     body: {
       client_id: 'client_id',
+      channel_id: 'site_id',
       code: 'J2lHm0cgXmnXpwDhjhLoyLJBoUAlBfxDY-AhjqGMC-o',
       code_verifier: expect.stringMatching(/./) as string,
       grant_type: 'authorization_code_pkce',
@@ -339,6 +341,7 @@ describe('Refresh Token', () => {
   const expectedBody = {
     body: {
       client_id: 'client_id',
+      channel_id: 'site_id',
       grant_type: 'refresh_token',
       refresh_token: 'refresh_token',
     },

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -174,6 +174,7 @@ export async function loginGuestUser(
 
   const tokenBody: TokenRequest = {
     client_id: slasClient.clientConfig.parameters.clientId,
+    channel_id: slasClient.clientConfig.parameters.siteId,
     code: authResponse.code,
     code_verifier: codeVerifier,
     grant_type: 'authorization_code_pkce',
@@ -259,6 +260,7 @@ export async function loginRegisteredUserB2C(
 
   const tokenBody = {
     client_id: slasClient.clientConfig.parameters.clientId,
+    channel_id: slasClient.clientConfig.parameters.siteId,
     code: authResponse.code,
     code_verifier: codeVerifier,
     grant_type: 'authorization_code_pkce',
@@ -289,6 +291,7 @@ export function refreshAccessToken(
     grant_type: 'refresh_token',
     refresh_token: parameters.refreshToken,
     client_id: slasClient.clientConfig.parameters.clientId,
+    channel_id: slasClient.clientConfig.parameters.siteId
   };
 
   return slasClient.getAccessToken({body});

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -121,6 +121,7 @@ export async function authorize(
   const options = {
     parameters: {
       client_id: slasClient.clientConfig.parameters.clientId,
+      channel_id: slasClient.clientConfig.parameters.siteId,
       code_challenge: codeChallenge,
       ...(parameters.hint && {hint: parameters.hint}),
       organizationId: slasClient.clientConfig.parameters.organizationId,


### PR DESCRIPTION
Hi team,

With the recent SLAS release on Sept. 13, SLAS now supports client-id per site rather than client-id per instance. As a result of this change, the calls to log in a user must now include the `channel_id` parameter (which corresponds to the siteId).  

This PR updates the SLAS helper to include `channel_id` when we are calling SLAS endpoints.