### PR TITLE
Pre-release housekeeping

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,7 +43,7 @@
           "",
           {
             "pattern": "^ \\* Copyright \\(c\\) \\d{4}, (salesforce.com, inc|Salesforce, Inc)\\.$",
-            "template": " * Copyright (c) 2022, Salesforce, Inc."
+            "template": " * Copyright (c) 2023, Salesforce, Inc."
           },
           " * All rights reserved.",
           " * SPDX-License-Identifier: BSD-3-Clause",

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2020, Salesforce.com, Inc.
+Copyright (c) 2023, Salesforce, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "autoprefixer": "9.8.8",
     "bundlesize": "^0.18.1",
     "depcheck": "^1.4.3",
+    "dotenv": "^16.0.3",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "18.2.1",
     "eslint-config-prettier": "^8.5.0",

--- a/scripts/updateApis.ts
+++ b/scripts/updateApis.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, salesforce.com, inc.
+ * Copyright (c) 2023, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -7,8 +7,17 @@
 
 import path from 'path';
 import fs from 'fs-extra';
+import dotenv from 'dotenv';
 import {updateApis} from './utils';
 import {API_LIST} from './config';
+
+dotenv.config();
+
+if (!process.env.ANYPOINT_USERNAME || !process.env.ANYPOINT_PASSWORD) {
+  throw new Error(
+    'Please ensure that ANYPOINT_USERNAME and ANYPOINT_PASSWORD environment variables have been set.'
+  );
+}
 
 const OLD_APIS_PATH = path.join(__dirname, '../temp/oldApis');
 const PRODUCTION_API_PATH = path.join(__dirname, '../apis');

--- a/yarn.lock
+++ b/yarn.lock
@@ -7104,6 +7104,11 @@ dotenv@8.6.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 duplexer2@~0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"


### PR DESCRIPTION
1. Load env vars from `.env`. That's done when using `raml-toolkit` directly, but the update APIs script here bypasses that for whatever reason.
2. Copyright year.