### PR TITLE
Add prettify helper to make types more readable.

### DIFF
--- a/src/static/helpers/types.ts
+++ b/src/static/helpers/types.ts
@@ -1,20 +1,36 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2023, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+/**
+ * Makes a type easier to read.
+ */
+type Prettify<T> = NonNullable<{
+  [K in keyof T]: T[K];
+}>;
+
+/**
+ * Generates the types required on a method, based on those provided in the config.
+ */
 export type CompositeParameters<
   MethodParameters extends Record<string, unknown>,
   ConfigParameters extends Record<string, unknown>
-> = Omit<MethodParameters, keyof ConfigParameters> & Partial<MethodParameters>;
+> = Prettify<
+  Omit<MethodParameters, keyof ConfigParameters> & Partial<MethodParameters>
+>;
 
+/**
+ * If an object has a `parameters` property, and the `parameters` object has required properties,
+ * then the `parameters` property on the root object is marked as required.
+ */
 export type RequireParametersUnlessAllAreOptional<
   T extends {parameters?: Record<string, unknown>}
 > = Record<string, never> extends NonNullable<T['parameters']>
   ? T
-  : T & Required<Pick<T, 'parameters'>>;
+  : Prettify<T & Required<Pick<T, 'parameters'>>>;
 
 /**
  * Template parameters used in the base URI of all API endpoints. `version` will default to `"v1"`


### PR DESCRIPTION
For `ShopperBaskets<{shortCode: string; organizationId: string}>['getBasket']`, the type is displayed as:
```ts
(method) ShopperBaskets<{ shortCode: string; organizationId: string; }>.getBasket(options?: ({
    parameters?: (Omit<{
        organizationId: string;
        basketId: string;
        siteId: string;
        locale?: string | undefined;
    }, "organizationId" | "shortCode"> & Partial<{
        organizationId: string;
        basketId: string;
        siteId: string;
        locale?: string | undefined;
    }>) | undefined;
    headers?: {
        ...;
    } | undefined;
} & Required<...>) | undefined): Promise<...> (+1 overload)
```

With this change, it's significantly easier to read:
```ts
(method) ShopperBaskets<{ shortCode: string; organizationId: string; }>.getBasket(options?: {
    parameters: {
        siteId: string;
        locale?: string | undefined;
        basketId: string;
        organizationId?: string | undefined;
    };
    headers?: {
        [key: string]: string;
    } | undefined;
} | undefined): Promise<...> (+1 overload)
```