### PR TITLE
Fix circular reference.

### DIFF
--- a/src/static/templateUrl.ts
+++ b/src/static/templateUrl.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import type {PathParameters, QueryParameters} from './helpers';
+import type {PathParameters, QueryParameters} from './helpers/types';
 
 export default class TemplateURL extends URL {
   /**


### PR DESCRIPTION
The cycle is `src/lib/shopperLogin.ts` -> `src/static/templateUrl.ts` -> `src/static/helpers/index.ts` -> `src/static/helpers/slasHelper.ts` -> `src/lib/shopperLogin.ts` 🔁. Changing the import from `helpers/index` to `helpers/types` breaks the cycle.