### PR TITLE
Release v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v1.10.1
+
+#### Bug fixes
+
+- The 'To is not a function' [issue](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/issues/122) is fixed.
+
 ## v1.10.0
 
 #### Enhancements

--- a/docs/modules/helpers.html
+++ b/docs/modules/helpers.html
@@ -332,7 +332,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-module">
 					<a name="fetch-1" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagConst">Const</span> fetch</h3>
-					<div class="tsd-signature tsd-kind-icon">fetch<span class="tsd-signature-symbol">:</span> <a href="clientconfig.html#fetchfunction" class="tsd-signature-type">FetchFunction</a><span class="tsd-signature-symbol"> = (() &#x3D;&gt; {if (isNode) {// eslint-disable-next-line global-require, @typescript-eslint/no-unsafe-returnreturn require(&#x27;node-fetch&#x27;);}if (!hasFetchAvailable)throw new Error(&#x27;Bad environment: it is not a node environment but fetch is not defined&#x27;);return globalObject.fetch;})()</span></div>
+					<div class="tsd-signature tsd-kind-icon">fetch<span class="tsd-signature-symbol">:</span> <a href="clientconfig.html#fetchfunction" class="tsd-signature-type">FetchFunction</a><span class="tsd-signature-symbol"> = (() &#x3D;&gt; {if (isNode) {// eslint-disable-next-line global-require, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-member-accessreturn require(&#x27;node-fetch&#x27;).default;}if (!hasFetchAvailable)throw new Error(&#x27;Bad environment: it is not a node environment but fetch is not defined&#x27;);return globalObject.fetch;})()</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in src/lib/helpers/environment.ts:28</li>

--- a/docs/modules/version.html
+++ b/docs/modules/version.html
@@ -95,7 +95,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-module">
 					<a name="user_agent_value" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagConst">Const</span> USER_<wbr>AGENT_<wbr>VALUE</h3>
-					<div class="tsd-signature tsd-kind-icon">USER_<wbr>AGENT_<wbr>VALUE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"commerce-sdk-isomorphic@1.9.0"</span><span class="tsd-signature-symbol"> = &quot;commerce-sdk-isomorphic@1.9.0&quot;</span></div>
+					<div class="tsd-signature tsd-kind-icon">USER_<wbr>AGENT_<wbr>VALUE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"commerce-sdk-isomorphic@1.10.0"</span><span class="tsd-signature-symbol"> = &quot;commerce-sdk-isomorphic@1.10.0&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in src/lib/version.ts:2</li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commerce-sdk-isomorphic",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "private": false,
   "description": "Salesforce Commerce SDK Isomorphic",
   "bugs": {

--- a/src/static/helpers/environment.ts
+++ b/src/static/helpers/environment.ts
@@ -27,6 +27,7 @@ export const hasFetchAvailable = typeof globalObject.fetch === 'function';
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 export const fetch: FetchFunction = (() => {
   if (isNode) {
+    // .default is added because the newer versions of babel doesn't get the default export automatically for require().
     // eslint-disable-next-line global-require, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-member-access
     return require('node-fetch').default;
   }


### PR DESCRIPTION
## v1.10.1

#### Bug fixes

- The 'To is not a function' [issue](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/issues/122) is fixed.