### PR TITLE
DO NOT MERGE - Add a separate function for calling getAccessToken

### DIFF
--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -148,6 +148,70 @@ export async function authorize(
 }
 
 /**
+ * Wrapper for the /token endpoint. Depending on the parameters provided, will set up different grant types.
+ * @param slasClient a configured instance of the ShopperLogin SDK client
+ */
+export async function getAccessToken(
+  slasClient: ShopperLogin<{
+  shortCode: string;
+  organizationId: string;
+  clientId: string;
+  siteId: string;
+}>,
+parameters: {
+  redirectURI: string;
+  refreshToken?: string;
+  codeVerifier?: string;
+  code?: string;
+  usid?: string;
+},
+credentials?: {
+  client_id: string;
+  client_secret: string;
+}
+): Promise<TokenResponse> {
+
+  let tokenHeader = {}
+  if (credentials) {
+    const authorization = `Basic ${stringToBase64(
+      `${credentials.client_id}:${credentials.client_secret}`
+    )}`;
+
+    tokenHeader = {
+        Authorization: authorization
+    }
+  }
+
+  const grantType = parameters.refreshToken ? 'refresh_token'
+    : parameters.codeVerifier ? 'authorization_code_pkce'
+    : parameters.code ? 'authorization_code'
+    : 'client_credentials'
+
+  const tokenBody: TokenRequest = {
+    client_id: slasClient.clientConfig.parameters.clientId,
+    channel_id: slasClient.clientConfig.parameters.siteId,
+    grant_type: grantType,
+    redirect_uri: parameters.redirectURI
+  };
+
+  if (parameters.refreshToken) {
+    tokenBody.refresh_token = parameters.refreshToken
+  } else if (parameters.codeVerifier) {
+    tokenBody.code = parameters.code,
+    tokenBody.code_verifier = parameters.codeVerifier
+  } else if (parameters.code) {
+    tokenBody.code = parameters.code
+  }
+
+  if (parameters.usid) {
+    tokenBody.usid = parameters.usid
+  }
+
+  return slasClient.getAccessToken({headers: tokenHeader, body: tokenBody});
+}
+
+
+/**
  * A single function to execute the ShopperLogin Public Client Guest Login with proof key for code exchange flow as described in the [API documentation](https://developer.salesforce.com/docs/commerce/commerce-api/references?meta=shopper-login:Summary).
  * @param slasClient a configured instance of the ShopperLogin SDK client.
  * @param parameters - parameters to pass in the API calls.


### PR DESCRIPTION
DO NOT MERGE

To support both public and private clients as well as 3rd party IDPs, we could export a function that allows for more flexibility in calling SLAS /token endpoint.

Thinking is that if a refresh token is included, we can assume the user wants a refresh token login. This grant type supersedes all other types of request.

If no refresh token, check if the user provides a code verifier. If yes, assume the user is using a SLAS public client (only public clients need to provide a code verifier as the [PKCE](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-proof-key-for-code-exchange-pkce))

If no code verifier, we can assume the user is using a SLAS private client. If a code is still provided, set grant_type to `authorization_code`. This is used for registered user federated login.

If no code is provided, assume we are logging in a guest user via SLAS private client and set grant_type to `client_credentials`
