### PR TITLE
Feat: Add support for custom query parameters @W-13974911@

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,16 +18,16 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
           cache: npm
-      # - name: Cache node modules
-      #   id: cache-nodemodules
-      #   uses: actions/cache@v3
-      #   env:
-      #     cache-name: cache-node-modules
-      #   with:
-      #     path: "**/node_modules"
-      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Cache node modules
+        id: cache-nodemodules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install
-        # if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
+        if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: yarn run renderTemplates
       - run: yarn build:lib
       - run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   linux-tests:
     strategy:
       matrix:
-        node: [10, 12, 14, 16, 18]
+        node: [10, 12, 14, 16, 18, 20]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -18,16 +18,16 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
           cache: npm
-      - name: Cache node modules
-        id: cache-nodemodules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      # - name: Cache node modules
+      #   id: cache-nodemodules
+      #   uses: actions/cache@v3
+      #   env:
+      #     cache-name: cache-node-modules
+      #   with:
+      #     path: "**/node_modules"
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install
-        if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
+        # if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: yarn run renderTemplates
       - run: yarn build:lib
       - run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   linux-tests:
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [10, 12, 14, 16, 18]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Salesforce Commerce SDK (Isomorphic) allows easy interaction with the B2C Co
 
 ### Requirements
 
-- Node `^12.x`, `^14.x`, or `^16.x`
+- Node `^12.x`, `^14.x`, `^16.x`, or `^18.x`
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The Salesforce Commerce SDK (Isomorphic) allows easy interaction with the B2C Co
 
 ### Requirements
 
-- Node `^12.x`, `^14.x`, `^16.x`, or `^18.x`
+- Node `^12.x`, `^14.x`, `^16.x`, `^18.x` or `^20.x`
+
 
 ### Installation
 

--- a/src/test/parameters.test.ts
+++ b/src/test/parameters.test.ts
@@ -140,4 +140,40 @@ describe('Parameters', () => {
       new Error('Missing required path parameter: organizationId')
     );
   });
+
+  it('allow custom query params', async () => {
+    const customersClient = new ShopperCustomers({
+      parameters: {
+        // shortCode is a base URI parameter, not path/query, so it *must* be in the config
+        shortCode: SHORT_CODE,
+      },
+    });
+
+    const options = {
+      parameters: {
+        siteId: SITE_ID,
+        organizationId: ORGANIZATION_ID,
+        clientId: CLIENT_ID,
+        c_validCustomParam: 'custom_param',
+        invalidParam: 'invalid_param',
+      },
+      body: {type: 'guest'},
+    };
+
+    nock(`https://${SHORT_CODE}.api.commercecloud.salesforce.com`)
+      .post(
+        `/customer/shopper-customers/v1/organizations/${ORGANIZATION_ID}/customers/actions/login`
+      )
+      .query({
+        siteId: SITE_ID,
+        clientId: CLIENT_ID,
+        // expect `c_validCustomParam` but not `invalidParam`
+        c_validCustomParam: 'custom_param',
+      })
+      .reply(200, MOCK_RESPONSE);
+
+    const response = await customersClient.authorizeCustomer(options);
+
+    expect(response).toEqual(MOCK_RESPONSE);
+  });
 });

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -33,7 +33,7 @@
           {{#each request.queryParameters}}
           {{{name}}}{{#if (not (is required "true"))}}?{{/if}}: {{{ getTypeFromParameter this}}}
           {{/each}}
-        }, ConfigParameters>,
+        } & { [key in `c_${string}`]: any }, ConfigParameters>,
         headers?: { [key: string]: string },
         {{#if (isRequestWithPayload request)}}
         body: {{{getPayloadTypeFromRequest request}}}
@@ -72,7 +72,7 @@
           {{#each request.queryParameters}}
           {{{name}}}{{#if (not (is required "true"))}}?{{/if}}: {{{ getTypeFromParameter this}}}
           {{/each}}
-        }, ConfigParameters>,
+        } & { [key in `c_${string}`]: any }, ConfigParameters>,
         headers?: { [key: string]: string },
         {{#if (isRequestWithPayload request)}}
         body: {{{getPayloadTypeFromRequest request}}}
@@ -113,7 +113,7 @@
           {{#each request.queryParameters}}
           {{{name}}}{{#if (not (is required "true"))}}?{{/if}}: {{{ getTypeFromParameter this}}}
           {{/each}}
-        }, ConfigParameters>,
+        } & { [key in `c_${string}`]: any }, ConfigParameters>,
         headers?: { [key: string]: string },
         {{#if (isRequestWithPayload request)}}
         body: {{{getPayloadTypeFromRequest request}}}
@@ -142,7 +142,7 @@
       {{/if}}
       {{/each}}
 
-      const queryParams: {{{@root.name.upperCamelCase}}}QueryParameters = {};
+      const queryParams: {{{@root.name.upperCamelCase}}}QueryParameters & { [key in `c_${string}`]: any } = {};
       {{#each request.queryParameters}}
       if (optionParams["{{{name}}}"] !== undefined) {
         queryParams["{{{name}}}"] = optionParams["{{{name}}}"];
@@ -155,6 +155,12 @@
       }
       {{/if}}
       {{/each}}
+
+      Object.keys(optionParams).forEach((key) => {
+        if(key.startsWith('c_') && optionParams[key as keyof typeof optionParams] !== undefined) {
+          queryParams[key as keyof typeof queryParams] = optionParams[key as keyof typeof optionParams]
+        }
+      })
 
       const url = new TemplateURL(
         "{{{../path}}}",
@@ -186,6 +192,8 @@
         method: "{{loud method}}"
       };
 
+      console.log('REQUEST URL:', url.toString())
+      console.log('QUERY PARAMS:', queryParams)
       const response = await fetch(url.toString(), requestOptions);
       if (rawResponse) {
         return response;

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -192,8 +192,6 @@
         method: "{{loud method}}"
       };
 
-      console.log('REQUEST URL:', url.toString())
-      console.log('QUERY PARAMS:', queryParams)
       const response = await fetch(url.toString(), requestOptions);
       if (rawResponse) {
         return response;


### PR DESCRIPTION
This PR adds support for custom query parameters as SCAPI now supports SCAPI hooks: https://developer.salesforce.com/docs/commerce/commerce-api/references/about-commerce-api/about.html#08302023

Query params that begin with `c_` are considered custom query parameters and are passed onto the underlying SCAPI call. Any other query params that aren't a part of the SCAPI endpoint spec will be filtered out and not passed.

This PR also adds node 18 & 20 to the CI

Testing this PR takes a bit of set up:

1. `git clone git@github.com:SalesforceCommerceCloud/commerce-sdk-isomorphic.git`
2. `git checkout ju/support-custom-params`
3. `yarn install`
4. modify `templates/operations.ts.hbs` to add a `console.log()` to check query params:
```javascript
// operations.ts.hbs
...
      console.log('URL', url.toString())
      const response = await fetch(url.toString(), requestOptions);
      if (rawResponse) {
        return response;
...
```
5. `yarn run renderTemplates && yarn run build:lib`
6. Create a new node project in a separate directory: 
```bash
mkdir testCustomParams
cd testCustomParams
npm init -y
touch index.js
```

7. modify `package.json` in `testCustomParams` directory to point `commerce-sdk-isomorphic` to local directory in `dependencies` section and add `"type": "module"`:

```json
  "type": "module",
  "dependencies": {
    "commerce-sdk-isomorphic": "<insert_path_to_local_commerce-sdk-isomorphic>"
  }
```

8. `npm install`
9. Add test code to `index.js` and replace client creds

```javascript
import pkg from 'commerce-sdk-isomorphic';
const { helpers, ShopperLogin, ShopperProducts } = pkg;

// demo client credentials, if you have access to your own please replace them below.
const CLIENT_ID = "<CLIENT_ID>";
const ORG_ID = "<ORG_ID>";
const SHORT_CODE = "<SHORT_CODE>";
const SITE_ID = "<SITE_ID>";

// must be registered in SLAS. On server, redirectURI is never called
const redirectURI = "http://localhost:3000/callback";

// client configuration parameters
const clientConfig = {
  parameters: {
    clientId: CLIENT_ID,
    organizationId: ORG_ID,
    shortCode: SHORT_CODE,
    siteId: SITE_ID,
  },
};

const slasClient = new ShopperLogin(clientConfig);

// GUEST LOGIN
const guestTokenResponse = await helpers
  .loginGuestUser(slasClient, { redirectURI })
  .then((guestTokenResponse) => {
    console.log("Guest Token Response: ", guestTokenResponse);
    return guestTokenResponse;
  })
  .catch((error) =>
    console.log("Error fetching token for guest login: ", error)
  );

const shopperProducts = new ShopperProducts({
    ...clientConfig,
    headers: {authorization: `Bearer ${guestTokenResponse.access_token}`}
});

const productsResult = await shopperProducts.getProducts({
    parameters: {
        ids: "25720044M,25686395M", 
        expand: ["promotions", "images", "prices"],
        c_customParamOne: '1',
        c_customParamTwo: 2,
        c_customParamThree: 3,
        invalidParam: 'hello',
    }
})

console.log("productsResult: ", productsResult)
```

10. `node index.js > out.txt`

11. Observe `out.txt` and that the custom query params are included in the fetch call and invalid query params are excluded from the call:
```
URL https://<short_code>.api.commercecloud.salesforce.com/product/shopper-products/v1/organizations/<org_id>/products?ids=25720044M%2C25686395M&expand=promotions%2Cimages%2Cprices&siteId=RefArch&c_customParamOne=1&c_customParamTwo=2&c_customParamThree=3
```