### PR TITLE
@W-14758586: Support slas client

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ npm install commerce-sdk-isomorphic
 
 
 ### Configure the Isomorphic SDK
+**Note**
+You will see warning about using private helpers like this
+'This function can run on client-side. You are potentially exposing SLAS secret on browser. Make sure to keep it safe and secure!';. 
+The reason is because commerce-sdk-isomophic runs on both server and client. This warning is to remind developers to always keep their secret safe 
+and avoid expose it to client side
 
 ```javascript
 /**
@@ -57,6 +62,12 @@ const shopperLogin = new ShopperLogin(config);
 const {access_token, refresh_token} = await helpers.loginGuestUser(
   shopperLogin,
   {redirectURI: `${config.proxy}/callback`} // Callback URL must be configured in SLAS Admin
+);
+
+// Execute Private Client OAuth with PKCE to acquire guest tokens
+const {access_token, refresh_token} = await helpers.loginGuestUserPrivate(
+  shopperLogin,
+  {}, {clientSecret: 'slas-client-secret'}
 );
 
 const shopperSearch = new ShopperSearch({

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ const {access_token, refresh_token} = await helpers.loginGuestUser(
 );
 
 // Execute Private Client OAuth with PKCE to acquire guest tokens
-// ***WARNING*** Be cautious about using this function in the browser as you may end up exposing your client secret
+// ***WARNING*** Be cautious about using this function in the browser as you may end up exposing your client secret, only use it when you know your slas client secret is secured
 // const {access_token, refresh_token} = await helpers.loginGuestUserPrivate(
 //   shopperLogin,
 //   {}, {clientSecret: 'slas-client-secret'}
@@ -127,9 +127,7 @@ Client Shopper Login OAuth
 flows](https://developer.salesforce.com/docs/commerce/commerce-api/references?meta=shopper-login:Summary). See sample code above for guest login.
 
 **Note**
-If you use the SLAS private client helper functions in the browser, a warning will be displayed:
-`This function can run on client-side. You are potentially exposing SLAS secret on browser. Make sure to keep it safe and secure!`
-The reason is because commerce-sdk-isomophic runs on both server and client. This warning is to remind developers to always keep their secret safe and avoid expose it to client side
+If you use the SLAS private client helper functions in the browser, making sure that your slas client secret are secured since funcs can run in client-side.
 
 ## License Information
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,7 @@ npm install commerce-sdk-isomorphic
 
 
 ### Configure the Isomorphic SDK
-**Note**
-You will see warning about using private helpers like this
-'This function can run on client-side. You are potentially exposing SLAS secret on browser. Make sure to keep it safe and secure!';. 
-The reason is because commerce-sdk-isomophic runs on both server and client. This warning is to remind developers to always keep their secret safe 
-and avoid expose it to client side
+
 
 ```javascript
 /**
@@ -65,10 +61,11 @@ const {access_token, refresh_token} = await helpers.loginGuestUser(
 );
 
 // Execute Private Client OAuth with PKCE to acquire guest tokens
-const {access_token, refresh_token} = await helpers.loginGuestUserPrivate(
-  shopperLogin,
-  {}, {clientSecret: 'slas-client-secret'}
-);
+// ***WARNING*** Be cautious about using this function in the browser as you may end up exposing your client secret
+// const {access_token, refresh_token} = await helpers.loginGuestUserPrivate(
+//   shopperLogin,
+//   {}, {clientSecret: 'slas-client-secret'}
+// );
 
 const shopperSearch = new ShopperSearch({
   ...config,
@@ -123,11 +120,16 @@ _headers:_ A collection of key/value string pairs representing additional header
 
 _throwOnBadResponse:_ Default value is false. When set to true, the SDK throws an Error on responses with statuses that are not 2xx or 304.
 
-### Public Client Shopper Login helpers
+### Client Shopper Login helpers
 
 A collection of helper functions are available in this SDK to simplify [Public
 Client Shopper Login OAuth
 flows](https://developer.salesforce.com/docs/commerce/commerce-api/references?meta=shopper-login:Summary). See sample code above for guest login.
+
+**Note**
+If you use the SLAS private client helper functions in the browser, a warning will be displayed:
+`This function can run on client-side. You are potentially exposing SLAS secret on browser. Make sure to keep it safe and secure!`
+The reason is because commerce-sdk-isomophic runs on both server and client. This warning is to remind developers to always keep their secret safe and avoid expose it to client side
 
 ## License Information
 

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -308,6 +308,8 @@ describe('Registered B2C user flow', () => {
         code_verifier: expect.stringMatching(/./) as string,
         grant_type: 'authorization_code_pkce',
         redirect_uri: 'redirect_uri',
+        channel_id: 'site_id',
+        organizationId: 'organization_id',
         usid: '048adcfb-aa93-4978-be9e-09cb569fdcb9',
       },
     };
@@ -430,29 +432,8 @@ describe('Refresh Token', () => {
       },
       body: {
         grant_type: 'refresh_token',
-        refresh_token: parameters.refreshToken,
-      },
-    };
-    const token = slasHelper.refreshAccessToken(
-      createMockSlasClient(),
-      parameters,
-      {
-        clientSecret: credentialsPrivate.clientSecret,
-      }
-    );
-    expect(getAccessTokenMock).toBeCalledWith(expectedReqOpts);
-    expect(token).toStrictEqual(expectedTokenResponse);
-  });
-
-  test('refreshes the token warn users about using slas private client on', () => {
-    const expectedReqOpts = {
-      headers: {
-        Authorization: `Basic ${stringToBase64(
-          `client_id:${credentialsPrivate.clientSecret}`
-        )}`,
-      },
-      body: {
-        grant_type: 'refresh_token',
+        client_id: 'client_id',
+        channel_id: 'site_id',
         refresh_token: parameters.refreshToken,
       },
     };

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -176,7 +176,8 @@ export async function loginGuestUserPrivate(
   }
 ): Promise<TokenResponse> {
   if (onClient) {
-    // eslint-ignore-next-line we intentionally have warning here
+    // we intentionally have warning here
+    // eslint-disable-next-line
     console.warn(warningSlasSecretMsg);
   }
   const authorization = `Basic ${stringToBase64(
@@ -240,7 +241,7 @@ export async function loginGuestUser(
 /**
  * A single function to execute the ShopperLogin Public Client Registered User B2C Login with proof key for code exchange flow as described in the [API documentation](https://developer.salesforce.com/docs/commerce/commerce-api/references?meta=shopper-login:Summary).
  * @param slasClient a configured instance of the ShopperLogin SDK client.
- * @param credentials - the id and password to login with.
+ * @param credentials - the id and password and clientSecret (if applicable) to login with.
  * @param credentials.username - the id of the user to login with.
  * @param credentials.password - the password of the user to login with.
  * @param credentials.clientSecret - secret associated with client ID
@@ -259,7 +260,7 @@ export async function loginRegisteredUserB2C(
   credentials: {
     username: string;
     password: string;
-    clientSecret: string;
+    clientSecret?: string;
   },
   parameters: {
     redirectURI: string;
@@ -314,7 +315,8 @@ export async function loginRegisteredUserB2C(
   // using slas private client
   if (credentials.clientSecret) {
     if (onClient) {
-      // eslint-ignore-next-line we intentionally have warning here
+      // we intentionally have warning here
+      // eslint-disable-next-line
       console.warn(warningSlasSecretMsg);
     }
 
@@ -359,6 +361,7 @@ export async function loginRegisteredUserB2C(
  * @param parameters - parameters to pass in the API calls.
  * @param parameters.refreshToken - a valid refresh token to exchange for a new access token (and refresh token).
  * @param parameters.refreshToken - a valid refresh token to exchange for a new access token (and refresh token).
+ * @param credentials - the clientSecret (if applicable) to login with.
  * @param credentials.clientSecret - secret associated with client ID
  * @returns TokenResponse
  */
@@ -370,11 +373,12 @@ export function refreshAccessToken(
     siteId: string;
   }>,
   parameters: {refreshToken: string},
-  credentials: {clientSecret: string}
+  credentials?: {clientSecret?: string}
 ): Promise<TokenResponse> {
-  if (credentials.clientSecret) {
+  if (credentials && credentials.clientSecret) {
     if (onClient) {
-      // eslint-ignore-next-line we intentionally have warning here
+      // we intentionally have warning here
+      // eslint-disable-next-line
       console.warn(warningSlasSecretMsg);
     }
     const authorization = `Basic ${stringToBase64(

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -16,9 +16,6 @@ import {
 } from '../../lib/shopperLogin';
 import ResponseError from '../responseError';
 
-const warningSlasSecretMsg =
-  'This function can run on client-side. You are potentially exposing SLAS secret on browser. Make sure to keep it safe and secure!';
-
 export const stringToBase64 = isBrowser
   ? btoa
   : (unencoded: string): string => Buffer.from(unencoded).toString('base64');
@@ -152,7 +149,7 @@ export async function authorize(
 
 /**
  * A single function to execute the ShopperLogin Private Client Guest Login as described in the [API documentation](https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas-private-client.html).
- *
+ * **Note**: this func can run on client side. Only use this one when the slas client secret is secured.
  * @param slasClient - a configured instance of the ShopperLogin SDK client
  * @param credentials - client secret used for authentication
  * @param credentials.clientSecret - secret associated with client ID
@@ -174,12 +171,6 @@ export async function loginGuestUserPrivate(
     clientSecret: string;
   }
 ): Promise<TokenResponse> {
-  /* istanbul ignore next */
-  if (isBrowser) {
-    // we intentionally have warning here
-    // eslint-disable-next-line
-    console.warn(warningSlasSecretMsg);
-  }
   const authorization = `Basic ${stringToBase64(
     `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
   )}`;
@@ -240,6 +231,7 @@ export async function loginGuestUser(
 
 /**
  * A single function to execute the ShopperLogin Public Client Registered User B2C Login with proof key for code exchange flow as described in the [API documentation](https://developer.salesforce.com/docs/commerce/commerce-api/references?meta=shopper-login:Summary).
+ * **Note**: this func can run on client side. Only use private slas when the slas client secret is secured.
  * @param slasClient a configured instance of the ShopperLogin SDK client.
  * @param credentials - the id and password and clientSecret (if applicable) to login with.
  * @param credentials.username - the id of the user to login with.
@@ -324,13 +316,6 @@ export async function loginRegisteredUserB2C(
   };
   // using slas private client
   if (credentials.clientSecret) {
-    /* istanbul ignore next */
-    if (isBrowser) {
-      // we intentionally have warning here
-      // eslint-disable-next-line
-      console.warn(warningSlasSecretMsg);
-    }
-
     const authHeaderIdSecret = `Basic ${stringToBase64(
       `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
     )}`;
@@ -349,6 +334,7 @@ export async function loginRegisteredUserB2C(
 
 /**
  * Exchange a refresh token for a new access token.
+ * **Note**: this func can run on client side. Only use private slas when the slas client secret is secured.
  * @param slasClient a configured instance of the ShopperLogin SDK client.
  * @param parameters - parameters to pass in the API calls.
  * @param parameters.refreshToken - a valid refresh token to exchange for a new access token (and refresh token).
@@ -374,12 +360,6 @@ export function refreshAccessToken(
   };
 
   if (credentials && credentials.clientSecret) {
-    /* istanbul ignore next */
-    if (isBrowser) {
-      // we intentionally have warning here
-      // eslint-disable-next-line
-      console.warn(warningSlasSecretMsg);
-    }
     const authorization = `Basic ${stringToBase64(
       `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
     )}`;


### PR DESCRIPTION
This PR adds support for SLAS [private](https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas-private-client.html) client without making a breaking change.

How to test 
1. `git clone git@github.com:SalesforceCommerceCloud/commerce-sdk-isomorphic.git`
2. `git checkout support-slas-client`
3. yarn install
4. npm run renderTemplates && yarn build:lib
5. Create a node project in a separate directory
```
mkdir testSlasPrivateClient
cd testSlasPrivateClient
npm init -y
touch index.js
```
6. modify package.json in testSlasPrivateClient directory to point commerce-sdk-isomorphic to local directory in dependencies section and add "type": "module":
```
  "type": "module",
  "dependencies": {
    "commerce-sdk-isomorphic": "<insert_path_to_local_commerce-sdk-isomorphic>"
  }
```
7. npm install
8. Set up SLAS private client via API for the instance that you are testing on https://kv7kzm78.api.commercecloud.salesforce.com/shopper/auth-admin/v1/sso/login
9. Add test code to index.js and replace client creds
```
import pkg from 'commerce-sdk-isomorphic';
const { helpers, ShopperLogin, ShopperSearch } = pkg;

// demo client credentials, if you have access to your own please replace them below.
const CLIENT_ID = "<CLIENT_ID>";
const ORG_ID = "<ORG_ID>";
const SHORT_CODE = "<SHORT_CODE>";
const SITE_ID = "<SITE_ID>";
const CLIENT_SECRET = '<SLAS PRIVATE SECRET HERE>' // SLAS PRIVATE SECRET HERE
//  // EDIT HERE: Fill in with shopper credentials. Examples on how to register a shopper can be found in 04-register-shopper.ts
 const shopper = {
   username: <username>,
   password: <password>, // do not store password as plaintext. Store it in a secure location.
 };
// must be registered in SLAS. On server, redirectURI is never called
const redirectURI = "http://localhost:3000/callback";

// client configuration parameters
const clientConfig = {
    parameters: {
        clientId: CLIENT_ID,
        organizationId: ORG_ID,
        shortCode: SHORT_CODE,
        siteId: SITE_ID,
    },
};

const slasClient = new ShopperLogin(clientConfig);

// GUEST LOGIN
const guestTokenResponse = await helpers
    .loginGuestUserPrivate(slasClient, { redirectURI }, {clientSecret: CLIENT_SECRET})
    .then((guestTokenResponse) => {
        console.log("Guest Token Response: ", guestTokenResponse);
        return guestTokenResponse;
    })
    .catch((error) =>
        console.log("Error fetching token for guest login: ", error)
    );
// uncommnent the function you want to test
//  // REGISTERED B2C USER LOGIN
//  await helpers
//    .loginRegisteredUserB2C(
//      slasClient,
//      { username: shopper.username, password: shopper.password, clientSecret: CLIENT_SECRET },
//      { redirectURI }
//    )
//    .then((registeredUserTokenResponse) => {
//      console.log(
//        "Registered User Token Response: ",
//        registeredUserTokenResponse
//      );
//      return registeredUserTokenResponse;
//    })
//    .catch((error) =>
//      console.log("Error fetching token for registered user login: ", error)
//    );

// REFRESH TOKEN
//  const refreshTokenResponse = await helpers
//    .refreshAccessToken(slasClient, {
//      refreshToken: guestTokenResponse.refresh_token,
//    }, {clientSecret: CLIENT_SECRET})
//    .then((refreshTokenResponse) => {
//      console.log("Refresh Token Response: ", refreshTokenResponse);
//      return refreshTokenResponse;
//    })
//    .catch((error) => console.log("Error refreshing token: ", error));

// using JWT to make SCAPI API for additional check that private slas is working as expected
const shopperSearch = new ShopperSearch({
    ...clientConfig,
    headers: {authorization: `Bearer ${guestTokenResponse.access_token}`},
});

const searchResult = await shopperSearch.productSearch({
    parameters: {q: 'shirt'},
}).then((result) => {
    console.log("RESULT", result)
});

console.log(searchResult);
```
10. node index.js > out.txt
11. Observe out.txt and that the access_token is successfully retrieved with slas private secret and can be used to make SCAPI APIs

