### PR TITLE
Feat: support custom APIs @W-15111169@

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v1.14.0-dev
+
+#### Enchancements
+
+- Add support for custom APIs [#149](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/149)
+
 ## v1.13.1
 
 #### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Enchancements
 
-- Add support for custom APIs with `callCustomEndpoint` helper function [#149](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/149)
+- Add helper function `callCustomEndpoint` to call [Custom APIs](https://developer.salesforce.com/docs/commerce/commerce-api/guide/custom-apis.html) - [#149](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/149)
 
 ## v1.13.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Enchancements
 
-- Add support for custom APIs [#149](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/149)
+- Add support for custom APIs with `callCustomEndpoint` helper function [#149](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/149)
 
 ## v1.13.1
 

--- a/README.md
+++ b/README.md
@@ -151,18 +151,13 @@ Example usage:
 import pkg from 'commerce-sdk-isomorphic';
 const { helpers } = pkg;
 
-const CLIENT_ID = "<your-client-id>";
-const ORG_ID = "<your-org-id>";
-const SHORT_CODE = "<your-short-code>";
-const SITE_ID = "<your-site-id>";
-
 // client configuration parameters
 const clientConfigExample = {
   parameters: {
-    clientId: CLIENT_ID,
-    organizationId: ORG_ID,
-    shortCode: SHORT_CODE,
-    siteId: SITE_ID,
+    clientId: "<your-client-id>",
+    organizationId: "<your-org-id>",
+    shortCode: "<your-short-code>",
+    siteId: "<your-site-id>",
   }
 };
 
@@ -202,7 +197,6 @@ let postResponse = await helpers.callCustomEndpoint({
       queryParameter: 'queryParameter1',
     },
     headers: {
-      'Content-Type': 'application/json',
       authorization: `Bearer ${access_token}`
     },
     customApiPathParameters: customApiArgs,

--- a/README.md
+++ b/README.md
@@ -151,7 +151,6 @@ Example usage:
 import pkg from 'commerce-sdk-isomorphic';
 const { helpers } = pkg;
 
-// client configuration parameters
 const clientConfigExample = {
   parameters: {
     clientId: "<your-client-id>",

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Invalid query parameters that are not a part of the API and do not follow the `c
 
 ### Custom APIs
 
-The SDK supports calling custom APIs with a helper function, `callCustomEndpoint`.
+The SDK supports calling [custom APIs](https://developer.salesforce.com/docs/commerce/commerce-api/guide/custom-apis.html) with a helper function, `callCustomEndpoint`.
 
 Example usage:
 
@@ -157,26 +157,48 @@ const SHORT_CODE = "<your-short-code>";
 const SITE_ID = "<your-site-id>";
 
 // client configuration parameters
-const clientConfig = {
+const clientConfigExample = {
   parameters: {
     clientId: CLIENT_ID,
     organizationId: ORG_ID,
     shortCode: SHORT_CODE,
     siteId: SITE_ID,
-    // Custom API path parameters
-    endpointPath: 'customers',
-    apiName: 'loyalty-info',
-    apiVersion: 'v1', // defaults to v1 if not provided
-  },
+  }
 };
 
-// Flag to retrieve raw response or data from helper function
-const rawResponse = false;
+// Required params: apiName, endpointPath, shortCode, organizaitonId
+// Required path params can be passed into:
+// options.customApiPathParameters or clientConfig.parameters
+const customApiArgs = { 
+  endpointPath: 'customers',
+  apiName: 'loyalty-info',
+  apiVersion: 'v1', // defaults to v1 if not provided
+}
+
 const accessToken = '<INSERT ACCESS TOKEN HERE>';
 
-let response = await helpers.callCustomEndpoint(
-  {
+let getResponse = await helpers.callCustomEndpoint({
+  options: {
     method: 'GET',
+    parameters: {
+      queryParameter: 'queryParameter1',
+      siteId: SITE_ID,
+    },
+    headers: {
+      // Content-Type is defaulted to application/json if not provided
+      'Content-Type': 'application/json',
+      authorization: `Bearer ${access_token}`
+    },
+    customApiPathParameters: customApiArgs
+  }, 
+  clientConfig: clientConfigExample,
+  // Flag to retrieve raw response or data from helper function
+  rawResponse: false, 
+})
+
+let postResponse = await helpers.callCustomEndpoint({
+  options: {
+    method: 'POST',
     parameters: {
       queryParameter: 'queryParameter1',
       siteId: SITE_ID,
@@ -184,18 +206,22 @@ let response = await helpers.callCustomEndpoint(
     headers: {
       'Content-Type': 'application/json',
       authorization: `Bearer ${access_token}`
-    }
+    },
+    customApiPathParameters: customApiArgs,
+    body: JSON.stringify({ data: 'data' })
   }, 
-  clientConfig,
-  rawResponse
-)
+  clientConfig: clientConfigExample,
+  // Flag to retrieve raw response or data from helper function
+  rawResponse: false, 
+})
 
-console.log('RESPONSE: ', response)
+console.log('get response: ', getResponse)
+console.log('post response: ', postResponse)
 ```
 
 For more documentation about this helper function, please refer to the [commerce-sdk-isomorphic docs](https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/modules/helpers.html).
 
-For more information about custom APIs, please refer to the [Salesforce Developer Docs](https://developer.salesforce.com/docs/commerce/commerce-api/guide/custom-apis.html?q=custom+API)
+For more information about custom APIs, please refer to the [Salesforce Developer Docs](https://developer.salesforce.com/docs/commerce/commerce-api/guide/custom-apis.html)
 
 ## License Information
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,11 @@ const clientConfigExample = {
     organizationId: "<your-org-id>",
     shortCode: "<your-short-code>",
     siteId: "<your-site-id>",
-  }
+  },
+  // If not provided, it'll use the default production URI:
+  // 'https://{shortCode}.api.commercecloud.salesforce.com/custom/{apiName}/{apiVersion}'
+  // path parameters should be wrapped in curly braces like the default production URI
+  baseUri: "<your-base-uri>"
 };
 
 // Required params: apiName, endpointPath, shortCode, organizaitonId

--- a/README.md
+++ b/README.md
@@ -141,6 +141,62 @@ const searchResult = await shopperSearch.productSearch({
 
 Invalid query parameters that are not a part of the API and do not follow the `c_` custom query parameter convention will be filtered from the request and a warning will be displayed.
 
+### Custom APIs
+
+The SDK supports calling custom APIs with a helper function, `callCustomEndpoint`.
+
+Example usage:
+
+```javascript
+import pkg from 'commerce-sdk-isomorphic';
+const { helpers } = pkg;
+
+const CLIENT_ID = "<your-client-id>";
+const ORG_ID = "<your-org-id>";
+const SHORT_CODE = "<your-short-code>";
+const SITE_ID = "<your-site-id>";
+
+// client configuration parameters
+const clientConfig = {
+  parameters: {
+    clientId: CLIENT_ID,
+    organizationId: ORG_ID,
+    shortCode: SHORT_CODE,
+    siteId: SITE_ID,
+    // Custom API path parameters
+    endpointPath: 'customers',
+    apiName: 'loyalty-info',
+    apiVersion: 'v1', // defaults to v1 if not provided
+  },
+};
+
+// Flag to retrieve raw response or data from helper function
+const rawResponse = false;
+const accessToken = '<INSERT ACCESS TOKEN HERE>';
+
+let response = await helpers.callCustomEndpoint(
+  {
+    method: 'GET',
+    parameters: {
+      queryParameter: 'queryParameter1',
+      siteId: SITE_ID,
+    },
+    headers: {
+      'Content-Type': 'application/json',
+      authorization: `Bearer ${access_token}`
+    }
+  }, 
+  clientConfig,
+  rawResponse
+)
+
+console.log('RESPONSE: ', response)
+```
+
+For more documentation about this helper function, please refer to the [commerce-sdk-isomorphic docs](https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/modules/helpers.html).
+
+For more information about custom APIs, please refer to the [Salesforce Developer Docs](https://developer.salesforce.com/docs/commerce/commerce-api/guide/custom-apis.html?q=custom+API)
+
 ## License Information
 
 The Commerce SDK Isomorphic is licensed under BSD-3-Clause license. See the [license](./LICENSE.txt) for details.

--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ const clientConfigExample = {
 // Required path params can be passed into:
 // options.customApiPathParameters or clientConfig.parameters
 const customApiArgs = { 
-  endpointPath: 'customers',
   apiName: 'loyalty-info',
   apiVersion: 'v1', // defaults to v1 if not provided
+  endpointPath: 'customers'
 }
 
 const accessToken = '<INSERT ACCESS TOKEN HERE>';
@@ -182,7 +182,6 @@ let getResponse = await helpers.callCustomEndpoint({
     method: 'GET',
     parameters: {
       queryParameter: 'queryParameter1',
-      siteId: SITE_ID,
     },
     headers: {
       // Content-Type is defaulted to application/json if not provided
@@ -201,7 +200,6 @@ let postResponse = await helpers.callCustomEndpoint({
     method: 'POST',
     parameters: {
       queryParameter: 'queryParameter1',
-      siteId: SITE_ID,
     },
     headers: {
       'Content-Type': 'application/json',

--- a/src/static/config.ts
+++ b/src/static/config.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+// eslint-disable-next-line import/prefer-default-export
+export const CUSTOM_API_DEFAULT_BASE_URI =
+  'https://{shortCode}.api.commercecloud.salesforce.com/custom/{apiName}/{apiVersion}';

--- a/src/static/helpers/customApi.test.ts
+++ b/src/static/helpers/customApi.test.ts
@@ -43,6 +43,21 @@ describe('callCustomEndpoint', () => {
     body: 'Hello World',
   };
 
+  const queryParamString = new URLSearchParams({
+    ...options.parameters,
+    siteId: clientConfig.parameters.siteId as string,
+  }).toString();
+
+  // helper function that creates a copy of the options object
+  // and adds siteId to the parameters object that comes from clientConfig
+  const addSiteIdToOptions = (optionsObj: Record<string, unknown>) => ({
+    ...optionsObj,
+    parameters: {
+      ...(optionsObj.parameters as Record<string, unknown>),
+      siteId: clientConfig.parameters.siteId,
+    },
+  });
+
   test('throws an error when required path parameters are not passed', () => {
     const copyOptions = {
       ...options,
@@ -84,7 +99,9 @@ describe('callCustomEndpoint', () => {
 
     const expectedUrl = `${
       nockBasePath + nockEndpointPath
-    }?queryParam1=query+parameter+1&queryParam2=query+parameter+2`;
+    }?${queryParamString}`;
+    const expectedOptions = addSiteIdToOptions(copyOptions);
+
     const doFetchSpy = jest.spyOn(fetchHelper, 'doFetch');
 
     const response = (await callCustomEndpoint({
@@ -97,7 +114,7 @@ describe('callCustomEndpoint', () => {
     expect(doFetchSpy).toBeCalledTimes(1);
     expect(doFetchSpy).toBeCalledWith(
       expectedUrl,
-      copyOptions,
+      expectedOptions,
       expect.anything(),
       true
     );
@@ -116,7 +133,9 @@ describe('callCustomEndpoint', () => {
 
     const expectedUrl = `${
       nockBasePath + nockEndpointPath
-    }?queryParam1=query+parameter+1&queryParam2=query+parameter+2`;
+    }?${queryParamString}`;
+    const expectedOptions = addSiteIdToOptions(options);
+
     const expectedClientConfig = {
       ...clientConfig,
       baseUri:
@@ -128,7 +147,7 @@ describe('callCustomEndpoint', () => {
     expect(doFetchSpy).toBeCalledTimes(1);
     expect(doFetchSpy).toBeCalledWith(
       expectedUrl,
-      options,
+      expectedOptions,
       expectedClientConfig,
       true
     );
@@ -144,6 +163,7 @@ describe('callCustomEndpoint', () => {
         shortCode: 'clientconfig_shortcode',
         apiVersion: 'v2',
         organizationId: 'clientConfig_organizationId',
+        siteId: 'site_id',
       },
     };
 
@@ -171,7 +191,7 @@ describe('callCustomEndpoint', () => {
     // expected URL is a mix of both params
     const expectedUrl = `${
       nockBasePath + nockEndpointPath
-    }?queryParam1=query+parameter+1&queryParam2=query+parameter+2`;
+    }?${queryParamString}`;
 
     const doFetchSpy = jest.spyOn(fetchHelper, 'doFetch');
     await callCustomEndpoint({

--- a/src/static/helpers/customApi.test.ts
+++ b/src/static/helpers/customApi.test.ts
@@ -50,13 +50,11 @@ describe('callCustomEndpoint', () => {
       parameters: copyClientConfigParams,
     });
 
-    const asyncFuncCall = async (): Promise<void> => {
+    expect(async () => {
       // eslint-disable-next-line
-      // @ts-ignore
+      // @ts-ignore <-- we know it'll complain since we removed apiName
       await callCustomEndpoint(options, clientConfig);
-    };
-
-    expect(asyncFuncCall)
+    })
       .rejects.toThrow(
         'Missing required property in clientConfig.parameters: apiName'
       )

--- a/src/static/helpers/customApi.test.ts
+++ b/src/static/helpers/customApi.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import nock from 'nock';
+import {callCustomEndpoint} from './customApi';
+import * as fetchHelper from './fetchHelper';
+import ClientConfig from '../clientConfig';
+import {CustomParams} from '../../lib/helpers';
+
+describe('callCustomEndpoint', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  const clientConfigParameters: CustomParams = {
+    shortCode: 'short_code',
+    organizationId: 'organization_id',
+    clientId: 'client_id',
+    siteId: 'site_id',
+    apiName: 'api_name',
+    apiVersion: 'v2',
+    endpointPath: 'endpoint_path',
+  };
+
+  const options = {
+    method: 'POST',
+    parameters: {
+      queryParam1: 'query parameter 1',
+      queryParam2: 'query parameter 2',
+    },
+    headers: {
+      authorization: 'Bearer token',
+    },
+    body: {
+      data: 'data',
+    },
+  };
+
+  test('throws an error when required path parameters are not passed', () => {
+    // separate apiName using spread since we can't use 'delete' operator as it isn't marked as optional
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const {apiName, ...copyClientConfigParams} = clientConfigParameters;
+
+    const clientConfig = new ClientConfig({
+      parameters: copyClientConfigParams,
+    });
+
+    const asyncFuncCall = async (): Promise<void> => {
+      // eslint-disable-next-line
+      // @ts-ignore
+      await callCustomEndpoint(options, clientConfig);
+    };
+
+    expect(asyncFuncCall)
+      .rejects.toThrow(
+        'Missing required property in clientConfig.parameters: apiName'
+      )
+      .finally(() => 'resolve promise');
+  });
+
+  test('sets api version to "v1" if not provided', async () => {
+    const copyClientConfigParams = {...clientConfigParameters};
+    delete copyClientConfigParams.apiVersion;
+
+    const clientConfig = new ClientConfig({
+      parameters: copyClientConfigParams,
+    });
+
+    const {shortCode, apiName, organizationId, endpointPath} =
+      clientConfig.parameters;
+
+    const nockBasePath = `https://${shortCode}.api.commercecloud.salesforce.com`;
+    const nockEndpointPath = `/custom/${apiName}/v1/organizations/${organizationId}/${endpointPath}`;
+    nock(nockBasePath).post(nockEndpointPath).query(true).reply(200);
+
+    const expectedUrl = `${
+      nockBasePath + nockEndpointPath
+    }?queryParam1=query+parameter+1&queryParam2=query+parameter+2`;
+    const runFetchHelperSpy = jest.spyOn(fetchHelper, 'runFetchHelper');
+
+    await callCustomEndpoint(options, clientConfig);
+
+    expect(runFetchHelperSpy).toBeCalledTimes(1);
+    expect(runFetchHelperSpy).toBeCalledWith(
+      expectedUrl,
+      options,
+      expect.anything(),
+      undefined
+    );
+    expect(expectedUrl).toContain('/v1/');
+  });
+
+  test('runFetchHelper is called with the correct arguments', async () => {
+    const clientConfig = new ClientConfig({
+      parameters: clientConfigParameters,
+    });
+
+    const {shortCode, apiName, organizationId, endpointPath} =
+      clientConfig.parameters;
+
+    const nockBasePath = `https://${shortCode}.api.commercecloud.salesforce.com`;
+    const nockEndpointPath = `/custom/${apiName}/v2/organizations/${organizationId}/${endpointPath}`;
+    nock(nockBasePath).post(nockEndpointPath).query(true).reply(200);
+
+    const expectedUrl = `${
+      nockBasePath + nockEndpointPath
+    }?queryParam1=query+parameter+1&queryParam2=query+parameter+2`;
+    const expectedClientConfig = {
+      ...clientConfig,
+      baseUri:
+        'https://{shortCode}.api.commercecloud.salesforce.com/custom/{apiName}/{apiVersion}',
+    };
+
+    const runFetchHelperSpy = jest.spyOn(fetchHelper, 'runFetchHelper');
+    await callCustomEndpoint(options, clientConfig, true);
+    expect(runFetchHelperSpy).toBeCalledTimes(1);
+    expect(runFetchHelperSpy).toBeCalledWith(
+      expectedUrl,
+      options,
+      expectedClientConfig,
+      true
+    );
+  });
+});

--- a/src/static/helpers/customApi.test.ts
+++ b/src/static/helpers/customApi.test.ts
@@ -81,14 +81,19 @@ describe('callCustomEndpoint', () => {
     }?queryParam1=query+parameter+1&queryParam2=query+parameter+2`;
     const doFetchSpy = jest.spyOn(fetchHelper, 'doFetch');
 
-    await callCustomEndpoint(options, clientConfig);
+    const response = (await callCustomEndpoint(
+      options,
+      clientConfig,
+      true
+    )) as Response;
 
+    expect(response.status).toBe(200);
     expect(doFetchSpy).toBeCalledTimes(1);
     expect(doFetchSpy).toBeCalledWith(
       expectedUrl,
       options,
       expect.anything(),
-      undefined
+      true
     );
     expect(expectedUrl).toContain('/v1/');
   });

--- a/src/static/helpers/customApi.test.ts
+++ b/src/static/helpers/customApi.test.ts
@@ -79,12 +79,12 @@ describe('callCustomEndpoint', () => {
     const expectedUrl = `${
       nockBasePath + nockEndpointPath
     }?queryParam1=query+parameter+1&queryParam2=query+parameter+2`;
-    const runFetchHelperSpy = jest.spyOn(fetchHelper, 'runFetchHelper');
+    const doFetchSpy = jest.spyOn(fetchHelper, 'doFetch');
 
     await callCustomEndpoint(options, clientConfig);
 
-    expect(runFetchHelperSpy).toBeCalledTimes(1);
-    expect(runFetchHelperSpy).toBeCalledWith(
+    expect(doFetchSpy).toBeCalledTimes(1);
+    expect(doFetchSpy).toBeCalledWith(
       expectedUrl,
       options,
       expect.anything(),
@@ -93,7 +93,7 @@ describe('callCustomEndpoint', () => {
     expect(expectedUrl).toContain('/v1/');
   });
 
-  test('runFetchHelper is called with the correct arguments', async () => {
+  test('doFetch is called with the correct arguments', async () => {
     const clientConfig = new ClientConfig({
       parameters: clientConfigParameters,
     });
@@ -114,10 +114,10 @@ describe('callCustomEndpoint', () => {
         'https://{shortCode}.api.commercecloud.salesforce.com/custom/{apiName}/{apiVersion}',
     };
 
-    const runFetchHelperSpy = jest.spyOn(fetchHelper, 'runFetchHelper');
+    const doFetchSpy = jest.spyOn(fetchHelper, 'doFetch');
     await callCustomEndpoint(options, clientConfig, true);
-    expect(runFetchHelperSpy).toBeCalledTimes(1);
-    expect(runFetchHelperSpy).toBeCalledWith(
+    expect(doFetchSpy).toBeCalledTimes(1);
+    expect(doFetchSpy).toBeCalledWith(
       expectedUrl,
       options,
       expectedClientConfig,

--- a/src/static/helpers/customApi.ts
+++ b/src/static/helpers/customApi.ts
@@ -22,11 +22,13 @@ export const runFetchHelper = async (
     parameters?: {[key: string]: any}; // query parameters
     path: string;
     headers?: {
-      authorization: string;
+      authorization?: string;
     } & {[key: string]: string};
-    body?: {[key: string]: any};
+    body?: any,
+    // body?: {[key: string]: any}; // TODO: fix this
   },
-  clientConfig: ClientConfigInit<CustomParams>, // TODO: update Params
+  clientConfig: any,
+  // clientConfig: ClientConfigInit<CustomParams>, // TODO: update Params
   rawResponse?: boolean
 ): Promise<Response> => {
   const url = new TemplateURL(
@@ -44,6 +46,8 @@ export const runFetchHelper = async (
     ...options?.headers,
   };
 
+  // TODO: potentially pull this out of helper method
+  // and leave it in the template
   if (!isBrowser) {
     // Browsers forbid setting a custom user-agent header
     headers[USER_AGENT_HEADER] = [
@@ -72,7 +76,7 @@ export const runFetchHelper = async (
     response.status !== 304
   ) {
     throw new ResponseError(response);
-  } else {
+  } else { // TODO: figure out how to not respond with anything for void operations
     const text = await response.text();
     // It's ideal to get "{}" for an empty response body, but we won't throw if it's truly empty
     return text ? JSON.parse(text) : {};

--- a/src/static/helpers/customApi.ts
+++ b/src/static/helpers/customApi.ts
@@ -27,11 +27,11 @@ export interface CustomParams {
  * @param args.options.method? - The request HTTP operation. 'GET' is the default if no method is provided.
  * @param args.options.parameters? - Query parameters that are added to the request
  * @param args.options.customApiPathParameters? - Path parameters used for custom API. Required path parameters (apiName, endpointPath, organizationId, and shortCode) can be in this object, or args.clientConfig.parameters. apiVersion is defaulted to 'v1' if not provided.
- * @param args.options.headers? - Headers that are added to the request. Authorization header should be in this parameter or in the clientConfig.headers. If "Content-Type" is not provided, it will be defaulted to "application/json".
+ * @param args.options.headers? - Headers that are added to the request. Authorization header should be in this parameter or in the clientConfig.headers. If "Content-Type" is not provided in either header, it will be defaulted to "application/json".
  * @param args.options.body? - Body that is used for the request
  * @param args.clientConfig - Client Configuration object used by the SDK with properties that can affect the fetch call
  * @param args.clientConfig.parameters - Path parameters used for custom API endpoints. The required properties are: apiName, endpointPath, organizationId, and shortCode. An error will be thrown if these are not provided.
- * @param args.clientConfig.headers? - Additional headers that are added to the request. Authorization header should be in this argument or in the options?.headers. options?.headers will override any duplicate properties.
+ * @param args.clientConfig.headers? - Additional headers that are added to the request. Authorization header should be in this argument or in the options?.headers. options?.headers will override any duplicate properties. If "Content-Type" is not provided in either header, it will be defaulted to "application/json".
  * @param args.clientConfig.baseUri? - baseUri used for the request, where the path parameters are wrapped in curly braces. Default value is 'https://{shortCode}.api.commercecloud.salesforce.com/custom/{apiName}/{apiVersion}'
  * @param args.clientConfig.fetchOptions? - fetchOptions that are passed onto the fetch request
  * @param args.clientConfig.throwOnBadResponse? - flag that when set true will throw a response error if the fetch request fails (returns with a status code outside the range of 200-299 or 304 redirect)
@@ -103,6 +103,11 @@ export const callCustomEndpoint = async (args: {
   // Look for Content-Type header
   if (options.headers) {
     contentTypeKey = Object.keys(options.headers).find(
+      key => key.toLowerCase() === 'content-type'
+    );
+  }
+  if(clientConfigCopy.headers && !contentTypeKey) {
+    contentTypeKey = Object.keys(clientConfigCopy.headers).find(
       key => key.toLowerCase() === 'content-type'
     );
   }

--- a/src/static/helpers/customApi.ts
+++ b/src/static/helpers/customApi.ts
@@ -11,10 +11,10 @@ import TemplateURL from '../templateUrl';
 import {ClientConfigInit} from '../clientConfig';
 
 export interface CustomParams {
-  apiName: string;
+  apiName?: string;
   apiVersion?: string;
-  endpointPath: string;
-  organizationId: string;
+  endpointPath?: string;
+  organizationId?: string;
   shortCode: string;
   [key: string]: unknown;
 }
@@ -22,61 +22,78 @@ export interface CustomParams {
 /**
  * A helper function designed to make calls to a custom API endpoint
  * For more information about custom APIs, please refer to the [API documentation](https://developer.salesforce.com/docs/commerce/commerce-api/guide/custom-apis.html?q=custom+API)
- * @param options - An object containing any custom settings you want to apply to the request
- * @param options.method? - The request HTTP operation. 'GET' is the default if no method is provided.
- * @param options.parameters? - Query parameters that are added to the request
- * @param options.headers? - Headers that are added to the request. Authorization header should be in this parameter or in the clientConfig.headers
- * @param options.body? - Body that is used for the request
- * @param clientConfig - Client Configuration object used by the SDK with properties that can affect the fetch call
- * @param clientConfig.parameters - Path parameters used for custom API endpoints. The required properties are: apiName, endpointPath, organizationId, and shortCode. An error will be thrown if these are not provided.
- * @param clientConfig.headers? - Additional headers that are added to the request. Authorization header should be in this argument or in the options?.headers. options?.headers will override any duplicate properties.
- * @param clientConfig.baseUri? - baseUri used for the request, where the path parameters are wrapped in curly braces. Default value is 'https://{shortCode}.api.commercecloud.salesforce.com/custom/{apiName}/{apiVersion}'
- * @param clientConfig.fetchOptions? - fetchOptions that are passed onto the fetch request
- * @param clientConfig.throwOnBadResponse? - flag that when set true will throw a response error if the fetch request fails
- * @param clientConfig.proxy? - Routes API calls through a proxy when set
- * @param rawResponse? - Flag to return the raw response from the fetch call. True for raw response object, false for the data from the response
+ * @param args - Argument object containing data used for custom API request
+ * @param args.options - An object containing any custom settings you want to apply to the request
+ * @param args.options.method? - The request HTTP operation. 'GET' is the default if no method is provided.
+ * @param args.options.parameters? - Query parameters that are added to the request
+ * @param args.options.customApiPathParameters? - Path parameters used for custom API. Required path parameters (apiName, endpointPath, organizationId, and shortCode) can be in this object, or args.clientConfig.parameters. apiVersion is defaulted to 'v1' if not provided.
+ * @param args.options.headers? - Headers that are added to the request. Authorization header should be in this parameter or in the clientConfig.headers
+ * @param args.options.body? - Body that is used for the request
+ * @param args.clientConfig - Client Configuration object used by the SDK with properties that can affect the fetch call
+ * @param args.clientConfig.parameters - Path parameters used for custom API endpoints. The required properties are: apiName, endpointPath, organizationId, and shortCode. An error will be thrown if these are not provided.
+ * @param args.clientConfig.headers? - Additional headers that are added to the request. Authorization header should be in this argument or in the options?.headers. options?.headers will override any duplicate properties.
+ * @param args.clientConfig.baseUri? - baseUri used for the request, where the path parameters are wrapped in curly braces. Default value is 'https://{shortCode}.api.commercecloud.salesforce.com/custom/{apiName}/{apiVersion}'
+ * @param args.clientConfig.fetchOptions? - fetchOptions that are passed onto the fetch request
+ * @param args.clientConfig.throwOnBadResponse? - flag that when set true will throw a response error if the fetch request fails
+ * @param args.clientConfig.proxy? - Routes API calls through a proxy when set
+ * @param args.rawResponse? - Flag to return the raw response from the fetch call. True for raw response object, false for the data from the response
  * @returns Raw response or data from response based on rawResponse argument from fetch call
  */
-export const callCustomEndpoint = async (
+export const callCustomEndpoint = async (args: {
   options: {
     method?: string;
     parameters?: {
       [key: string]: string | number | boolean | string[] | number[];
     };
+    customApiPathParameters?: {
+      apiName?: string;
+      apiVersion?: string;
+      endpointPath?: string;
+      organizationId?: string;
+      shortCode?: string;
+    };
     headers?: {
       authorization?: string;
     } & {[key: string]: string};
     body?: BodyInit | globalThis.BodyInit | unknown;
-  },
-  clientConfig: ClientConfigInit<CustomParams>,
-  rawResponse?: boolean
-): Promise<Response | unknown> => {
+  };
+  clientConfig: ClientConfigInit<CustomParams>;
+  rawResponse?: boolean;
+}): Promise<Response | unknown> => {
+  const {options, clientConfig, rawResponse} = args;
+
   const requiredArgs = [
     'apiName',
     'endpointPath',
     'organizationId',
     'shortCode',
   ];
+
+  const pathParams: Record<string, unknown> = {
+    ...clientConfig.parameters,
+    ...options?.customApiPathParameters,
+  };
+
   requiredArgs.forEach(arg => {
-    if (!clientConfig.parameters[arg]) {
+    if (!pathParams[arg]) {
       throw new Error(
-        `Missing required property in clientConfig.parameters: ${arg}`
+        `Missing required property needed in args.options.customApiPathParameters or args.clientConfig.parameters: ${arg}`
       );
     }
   });
 
+  if (!pathParams.apiVersion) {
+    pathParams.apiVersion = 'v1';
+  }
+
   const defaultBaseUri =
     'https://{shortCode}.api.commercecloud.salesforce.com/custom/{apiName}/{apiVersion}';
-  let clientConfigCopy = clientConfig;
 
-  if (!clientConfig.baseUri || !clientConfig.parameters?.apiVersion) {
+  let clientConfigCopy = clientConfig;
+  if (!clientConfig.baseUri) {
     clientConfigCopy = {
       ...clientConfig,
-      ...(!clientConfig.baseUri && {baseUri: defaultBaseUri}),
-      parameters: {
-        ...clientConfig.parameters,
-        ...(!clientConfig.parameters?.apiVersion && {apiVersion: 'v1'}),
-      },
+      baseUri: defaultBaseUri,
     };
   }
 
@@ -84,7 +101,7 @@ export const callCustomEndpoint = async (
     '/organizations/{organizationId}/{endpointPath}',
     clientConfigCopy.baseUri as string,
     {
-      pathParams: clientConfigCopy.parameters as PathParameters,
+      pathParams: pathParams as PathParameters,
       queryParams: options.parameters,
       origin: clientConfigCopy.proxy,
     }

--- a/src/static/helpers/customApi.ts
+++ b/src/static/helpers/customApi.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import TemplateURL from '../templateUrl';
+import type {FetchOptions} from '../clientConfig';
+
+// TODO: implement
+// export const runFetchHelper = async (
+//   url: string,
+//   options?: {
+//     [key: string]: any;
+//   }
+// ): Promise<Response> => {
+
+// };
+
+// eslint-disable-next-line
+export const callCustomEndpoint = async (
+  options: {
+    method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
+    clientConfig: {
+      parameters: {
+        // path parameters
+        apiName: string;
+        apiVersion?: string; // default to v1 if not provided
+        endpointPath: string;
+        organizationId: string;
+        shortCode: string;
+      };
+      proxy?: string;
+      fetchOptions?: FetchOptions;
+    };
+    parameters?: {[key: string]: any}; // query parameters
+    headers?: {
+      Authorization: string;
+    } & {[key: string]: string};
+    body?: {[key: string]: any};
+  }
+  //   rawResponse?: boolean
+): Promise<Response> => {
+  // https://{shortCode}.api.commercecloud.salesforce.com/custom/{apiName}/{apiVersion}/organizations/{organizationId}/{endpointPath}
+  //  static readonly defaultBaseUri = "https://{shortCode}.api.commercecloud.salesforce.com/search/shopper-search/{version}/";
+  const CUSTOM_BASE_URI =
+    'https://{shortCode}.api.commercecloud.salesforce.com/custom/{apiName}/{apiVersion}';
+  const CUSTOM_PATH = '/organizations/{organizationId}/{endpointPath}';
+  const pathParams = {...options.clientConfig.parameters};
+  if (!pathParams.apiVersion) {
+    pathParams.apiVersion = 'v1';
+  }
+
+  const url = new TemplateURL(CUSTOM_PATH, CUSTOM_BASE_URI, {
+    pathParams,
+    queryParams: options.parameters,
+    origin: options.clientConfig.proxy,
+  });
+
+  const requestOptions = {
+    ...options.clientConfig.fetchOptions,
+    // TODO: this.clientConfig.transformRequest(options.body, headers)
+    body: options.body as BodyInit,
+    headers: options.headers,
+    method: options.method,
+  };
+
+  const response = await fetch(url.toString(), requestOptions);
+  //   if (rawResponse) {
+  //     return response;
+  //   }
+  //   const text = await response.text();
+  //   return text ? JSON.parse(text) : {};
+  return response;
+};

--- a/src/static/helpers/customApi.ts
+++ b/src/static/helpers/customApi.ts
@@ -8,22 +8,27 @@ import {BaseUriParameters, PathParameters} from 'lib/helpers';
 import TemplateURL from '../templateUrl';
 import type {FetchOptions} from '../clientConfig';
 import ResponseError from '../responseError';
-import {isBrowser, fetch} from './environment';
+import {fetch} from './environment';
 import {ClientConfigInit} from '../clientConfig';
 
-// TODO: check if you can pull out version in javascript, that way this doesn't have to be an .hbs file
-// import { USER_AGENT_HEADER, USER_AGENT_VALUE } from "../version";
-const USER_AGENT_HEADER = 'user-agent';
-const USER_AGENT_VALUE = 'commerce-sdk-isomorphic@1.13.1';
-
-// TODO: add js/tsdoc comment
-export const runFetchHelper = async <Params extends BaseUriParameters>( // TODO: also potentially extend { baseUri: string }
-  options: {
-    method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
-    parameters?: {
-      [key: string]: string | number | boolean | string[] | number[];
-    };
-    path: string;
+/**
+ * A wrapper function around fetch designed for making requests using the SDK
+ * @param url - The url of the resource that you wish to fetch
+ * @param options? - An object containing any custom settings you want to apply to the request
+ * @param options.method? - The request HTTP operation. The available options are: 'GET', 'POST', 'PATCH', 'PUT', and 'DELETE'. 'GET' is the default if no method is provided.
+ * @param options.headers? - Headers that are added to the request. Authorization header should be in this argument or in the clientConfig.headers
+ * @param options.body? - Body that is used for the request
+ * @param clientConfig? - Client Configuration object used by the SDK with properties that can affect the fetch call
+ * @param clientConfig.headers? - Additional headers that are added to the request. Authorization header should be in this argument or in the options?.headers. options?.headers will override any duplicate properties.
+ * @param clientConfig.fetchOptions? - fetchOptions that are passed onto the fetch request
+ * @param clientConfig.throwOnBadResponse? - flag that when set true will throw a response error if the fetch request fails
+ * @param rawResponse? - Flag to return the raw response from the fetch call. True for raw response object, false for the data from the response
+ * @returns Raw response or data from response based on rawResponse argument from fetch call
+ */
+export const runFetchHelper = async <Params extends BaseUriParameters>(
+  url: string,
+  options?: {
+    method?: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
     headers?: {
       authorization?: string;
     } & {[key: string]: string};
@@ -33,44 +38,28 @@ export const runFetchHelper = async <Params extends BaseUriParameters>( // TODO:
       | URLSearchParams
       | (BodyInit & (BodyInit | null));
   },
-  clientConfig: ClientConfigInit<Params>,
+  clientConfig?: ClientConfigInit<Params>,
   rawResponse?: boolean
-): Promise<Response | string> => {
-  const url = new TemplateURL(options.path, clientConfig.baseUri as string, {
-    pathParams: clientConfig.parameters as unknown as PathParameters,
-    queryParams: options?.parameters,
-    origin: clientConfig.proxy,
-  });
-
+): Promise<Response | unknown> => {
   const headers: Record<string, string> = {
     ...clientConfig?.headers,
     ...options?.headers,
   };
 
-  // TODO: potentially pull this out of helper method
-  // and leave it in the template
-  if (!isBrowser) {
-    // Browsers forbid setting a custom user-agent header
-    headers[USER_AGENT_HEADER] = [
-      headers[USER_AGENT_HEADER],
-      USER_AGENT_VALUE,
-    ].join(' ');
-  }
-
   const requestOptions: FetchOptions = {
-    ...clientConfig.fetchOptions,
+    ...clientConfig?.fetchOptions,
     headers,
     // TODO: probably need to fix this type
-    body: options.body as unknown as FormData & URLSearchParams,
-    method: options.method,
+    body: options?.body as unknown as FormData & URLSearchParams,
+    method: options?.method ?? 'GET',
   };
 
-  const response = await fetch(url.toString(), requestOptions);
+  const response = await fetch(url, requestOptions);
   if (rawResponse) {
     return response;
   }
   if (
-    clientConfig.throwOnBadResponse &&
+    clientConfig?.throwOnBadResponse &&
     !response.ok &&
     response.status !== 304
   ) {
@@ -78,7 +67,7 @@ export const runFetchHelper = async <Params extends BaseUriParameters>( // TODO:
   } else {
     const text = await response.text();
     // It's ideal to get "{}" for an empty response body, but we won't throw if it's truly empty
-    return (text ? JSON.parse(text) : {}) as string | Response;
+    return (text ? JSON.parse(text) : {}) as unknown | Response;
   }
 };
 
@@ -91,10 +80,25 @@ export interface CustomParams {
   [key: string]: unknown;
 }
 
-// TODO: add js/tsdoc comment
+/**
+ * A helper function designed to make calls to a custom API endpoint
+ * For more information about custom APIs, please refer to the [API documentation](https://developer.salesforce.com/docs/commerce/commerce-api/guide/custom-apis.html?q=custom+API)
+ * @param options - An object containing any custom settings you want to apply to the request
+ * @param options.method? - The request HTTP operation. The available options are: 'GET', 'POST', 'PATCH', 'PUT', and 'DELETE'. 'GET' is the default if no method is provided.
+ * @param options.parameters? - Query parameters that are added to the request
+ * @param options.headers? - Headers that are added to the request. Authorization header should be in this parameter or in the clientConfig.headers
+ * @param options.body? - Body that is used for the request
+ * @param clientConfig - Client Configuration object used by the SDK with properties that can affect the fetch call
+ * @param clientConfig.parameters - Path parameters used for custom API endpoints. The required properties are: apiName, endpointPath, organizationId, and shortCode. An error will be thrown if these are not provided.
+ * @param clientConfig.headers? - Additional headers that are added to the request. Authorization header should be in this argument or in the options?.headers. options?.headers will override any duplicate properties.
+ * @param clientConfig.fetchOptions? - fetchOptions that are passed onto the fetch request
+ * @param clientConfig.throwOnBadResponse? - flag that when set true will throw a response error if the fetch request fails
+ * @param rawResponse? - Flag to return the raw response from the fetch call. True for raw response object, false for the data from the response
+ * @returns Raw response or data from response based on rawResponse argument from fetch call
+ */
 export const callCustomEndpoint = async (
   options: {
-    method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
+    method?: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
     parameters?: {
       [key: string]: string | number | boolean | string[] | number[];
     };
@@ -109,7 +113,7 @@ export const callCustomEndpoint = async (
   },
   clientConfig: ClientConfigInit<CustomParams>,
   rawResponse?: boolean
-): Promise<Response | string> => {
+): Promise<Response | unknown> => {
   const requiredArgs = [
     'apiName',
     'endpointPath',
@@ -134,12 +138,15 @@ export const callCustomEndpoint = async (
     clientConfigCopy.parameters.apiVersion = 'v1';
   }
 
-  return runFetchHelper(
+  const url = new TemplateURL(
+    '/organizations/{organizationId}/{endpointPath}',
+    clientConfigCopy.baseUri as string,
     {
-      ...options,
-      path: '/organizations/{organizationId}/{endpointPath}',
-    },
-    clientConfigCopy,
-    rawResponse
+      pathParams: clientConfigCopy.parameters as unknown as PathParameters,
+      queryParams: options.parameters,
+      origin: clientConfig.proxy,
+    }
   );
+
+  return runFetchHelper(url.toString(), options, clientConfigCopy, rawResponse);
 };

--- a/src/static/helpers/customApi.ts
+++ b/src/static/helpers/customApi.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import {BodyInit} from 'node-fetch';
 import {PathParameters} from './types';
 import {runFetchHelper} from './fetchHelper';
 import TemplateURL from '../templateUrl';
@@ -44,10 +45,7 @@ export const callCustomEndpoint = async (
       authorization?: string;
     } & {[key: string]: string};
     // TODO: probably need to fix this type
-    body?:
-      | {[key: string]: unknown}
-      | URLSearchParams
-      | (BodyInit & (BodyInit | null));
+    body?: BodyInit | unknown;
   },
   clientConfig: ClientConfigInit<CustomParams>,
   rawResponse?: boolean

--- a/src/static/helpers/customApi.ts
+++ b/src/static/helpers/customApi.ts
@@ -1,75 +1,13 @@
 /*
- * Copyright (c) 2023, Salesforce, Inc.
+ * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {BaseUriParameters, PathParameters} from 'lib/helpers';
+import {PathParameters} from './types';
+import {runFetchHelper} from './fetchHelper';
 import TemplateURL from '../templateUrl';
-import type {FetchOptions} from '../clientConfig';
-import ResponseError from '../responseError';
-import {fetch} from './environment';
 import {ClientConfigInit} from '../clientConfig';
-
-/**
- * A wrapper function around fetch designed for making requests using the SDK
- * @param url - The url of the resource that you wish to fetch
- * @param options? - An object containing any custom settings you want to apply to the request
- * @param options.method? - The request HTTP operation. The available options are: 'GET', 'POST', 'PATCH', 'PUT', and 'DELETE'. 'GET' is the default if no method is provided.
- * @param options.headers? - Headers that are added to the request. Authorization header should be in this argument or in the clientConfig.headers
- * @param options.body? - Body that is used for the request
- * @param clientConfig? - Client Configuration object used by the SDK with properties that can affect the fetch call
- * @param clientConfig.headers? - Additional headers that are added to the request. Authorization header should be in this argument or in the options?.headers. options?.headers will override any duplicate properties.
- * @param clientConfig.fetchOptions? - fetchOptions that are passed onto the fetch request
- * @param clientConfig.throwOnBadResponse? - flag that when set true will throw a response error if the fetch request fails
- * @param rawResponse? - Flag to return the raw response from the fetch call. True for raw response object, false for the data from the response
- * @returns Raw response or data from response based on rawResponse argument from fetch call
- */
-export const runFetchHelper = async <Params extends BaseUriParameters>(
-  url: string,
-  options?: {
-    method?: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
-    headers?: {
-      authorization?: string;
-    } & {[key: string]: string};
-    // TODO: probably need to fix this type
-    body?:
-      | {[key: string]: unknown}
-      | URLSearchParams
-      | (BodyInit & (BodyInit | null));
-  },
-  clientConfig?: ClientConfigInit<Params>,
-  rawResponse?: boolean
-): Promise<Response | unknown> => {
-  const headers: Record<string, string> = {
-    ...clientConfig?.headers,
-    ...options?.headers,
-  };
-
-  const requestOptions: FetchOptions = {
-    ...clientConfig?.fetchOptions,
-    headers,
-    // TODO: probably need to fix this type
-    body: options?.body as unknown as FormData & URLSearchParams,
-    method: options?.method ?? 'GET',
-  };
-
-  const response = await fetch(url, requestOptions);
-  if (rawResponse) {
-    return response;
-  }
-  if (
-    clientConfig?.throwOnBadResponse &&
-    !response.ok &&
-    response.status !== 304
-  ) {
-    throw new ResponseError(response);
-  } else {
-    const text = await response.text();
-    // It's ideal to get "{}" for an empty response body, but we won't throw if it's truly empty
-    return (text ? JSON.parse(text) : {}) as unknown | Response;
-  }
-};
 
 export interface CustomParams {
   apiName: string;
@@ -84,7 +22,7 @@ export interface CustomParams {
  * A helper function designed to make calls to a custom API endpoint
  * For more information about custom APIs, please refer to the [API documentation](https://developer.salesforce.com/docs/commerce/commerce-api/guide/custom-apis.html?q=custom+API)
  * @param options - An object containing any custom settings you want to apply to the request
- * @param options.method? - The request HTTP operation. The available options are: 'GET', 'POST', 'PATCH', 'PUT', and 'DELETE'. 'GET' is the default if no method is provided.
+ * @param options.method? - The request HTTP operation. 'GET' is the default if no method is provided.
  * @param options.parameters? - Query parameters that are added to the request
  * @param options.headers? - Headers that are added to the request. Authorization header should be in this parameter or in the clientConfig.headers
  * @param options.body? - Body that is used for the request
@@ -98,7 +36,7 @@ export interface CustomParams {
  */
 export const callCustomEndpoint = async (
   options: {
-    method?: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
+    method?: string;
     parameters?: {
       [key: string]: string | number | boolean | string[] | number[];
     };

--- a/src/static/helpers/customApi.ts
+++ b/src/static/helpers/customApi.ts
@@ -6,7 +6,7 @@
  */
 import {BodyInit} from 'node-fetch';
 import {PathParameters} from './types';
-import {runFetchHelper} from './fetchHelper';
+import {doFetch} from './fetchHelper';
 import TemplateURL from '../templateUrl';
 import {ClientConfigInit} from '../clientConfig';
 
@@ -84,5 +84,5 @@ export const callCustomEndpoint = async (
     }
   );
 
-  return runFetchHelper(url.toString(), options, clientConfigCopy, rawResponse);
+  return doFetch(url.toString(), options, clientConfigCopy, rawResponse);
 };

--- a/src/static/helpers/customApi.ts
+++ b/src/static/helpers/customApi.ts
@@ -65,17 +65,18 @@ export const callCustomEndpoint = async (
     }
   });
 
-  const defaultBaseUri = 'https://{shortCode}.api.commercecloud.salesforce.com/custom/{apiName}/{apiVersion}'
-  let clientConfigCopy = clientConfig
-  
-  if(!clientConfig.baseUri || !clientConfig.parameters?.apiVersion) {
+  const defaultBaseUri =
+    'https://{shortCode}.api.commercecloud.salesforce.com/custom/{apiName}/{apiVersion}';
+  let clientConfigCopy = clientConfig;
+
+  if (!clientConfig.baseUri || !clientConfig.parameters?.apiVersion) {
     clientConfigCopy = {
       ...clientConfig,
-      ...(!clientConfig.baseUri && { baseUri: defaultBaseUri }),
+      ...(!clientConfig.baseUri && {baseUri: defaultBaseUri}),
       parameters: {
         ...clientConfig.parameters,
-        ...(!clientConfig.parameters?.apiVersion && { apiVersion: 'v1' })
-      }
+        ...(!clientConfig.parameters?.apiVersion && {apiVersion: 'v1'}),
+      },
     };
   }
 

--- a/src/static/helpers/customApi.ts
+++ b/src/static/helpers/customApi.ts
@@ -16,6 +16,7 @@ import ClientConfig, {ClientConfigInit} from '../clientConfig';
 const USER_AGENT_HEADER = 'user-agent';
 const USER_AGENT_VALUE = 'commerce-sdk-isomorphic@1.13.1';
 
+// TODO: add js/tsdoc comment
 export const runFetchHelper = async (
   options: {
     method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
@@ -92,13 +93,14 @@ export interface CustomParams {
   [key: string]: any;
 }
 
+// TODO: add js/tsdoc comment
 // eslint-disable-next-line
 export const callCustomEndpoint = async (
   options: {
     method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
     parameters?: {[key: string]: any}; // query parameters
     headers?: {
-      authorization: string;
+      authorization?: string;
     } & {[key: string]: string};
     body?: {[key: string]: any};
   },

--- a/src/static/helpers/customApi.ts
+++ b/src/static/helpers/customApi.ts
@@ -106,7 +106,7 @@ export const callCustomEndpoint = async (args: {
       key => key.toLowerCase() === 'content-type'
     );
   }
-  if(clientConfigCopy.headers && !contentTypeKey) {
+  if (clientConfigCopy.headers && !contentTypeKey) {
     contentTypeKey = Object.keys(clientConfigCopy.headers).find(
       key => key.toLowerCase() === 'content-type'
     );

--- a/src/static/helpers/customApi.ts
+++ b/src/static/helpers/customApi.ts
@@ -9,6 +9,7 @@ import {PathParameters} from './types';
 import {doFetch} from './fetchHelper';
 import TemplateURL from '../templateUrl';
 import {ClientConfigInit} from '../clientConfig';
+import {CUSTOM_API_DEFAULT_BASE_URI} from '../config';
 
 // Helper method to find Content Type header
 // returns true if it exists, false otherwise
@@ -100,14 +101,11 @@ export const callCustomEndpoint = async (args: {
     pathParams.apiVersion = 'v1';
   }
 
-  const defaultBaseUri =
-    'https://{shortCode}.api.commercecloud.salesforce.com/custom/{apiName}/{apiVersion}';
-
   let clientConfigCopy = clientConfig;
   if (!clientConfig.baseUri) {
     clientConfigCopy = {
       ...clientConfig,
-      baseUri: defaultBaseUri,
+      baseUri: CUSTOM_API_DEFAULT_BASE_URI,
     };
   }
 

--- a/src/static/helpers/environment.ts
+++ b/src/static/helpers/environment.ts
@@ -32,6 +32,8 @@ export const fetch: FetchFunction = (() => {
     return require('node-fetch').default;
   }
 
+  // difficult to test in node environment
+  /* istanbul ignore next */
   if (!hasFetchAvailable)
     throw new Error(
       'Bad environment: it is not a node environment but fetch is not defined'

--- a/src/static/helpers/fetchHelper.test.ts
+++ b/src/static/helpers/fetchHelper.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2023, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import nock from 'nock';
+import {Response} from 'node-fetch';
+import * as environment from './environment';
+import ClientConfig from '../clientConfig';
+import {runFetchHelper} from './fetchHelper';
+
+describe('runFetchHelper', () => {
+  const basePath = 'https://short_code.api.commercecloud.salesforce.com';
+  const endpointPath =
+    '/checkout/shopper-baskets/v1/organizations/organization_id/baskets';
+  const url = `${basePath + endpointPath}?siteId=site_id`;
+
+  const clientConfig = new ClientConfig({
+    parameters: {
+      shortCode: 'short_code',
+      organizationId: 'organization_id',
+      clientId: 'client_id',
+      siteId: 'site_id',
+    },
+    headers: {
+      clientConfigHeader: 'clientConfigHeader',
+      repeatHeader: 'clientConfig.headers',
+    },
+    fetchOptions: {
+      cache: 'no-cache',
+    },
+  });
+
+  const options = {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer token',
+      repeatHeader: 'options.headers',
+    },
+    body: {
+      data: 'data',
+    },
+  };
+
+  const responseBody = {message: 'request has matched'};
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  test('uses headers from both clientConfig and headers object', async () => {
+    nock(basePath, {
+      reqheaders: {
+        authorization: 'Bearer token',
+        repeatHeader: 'options.headers', // options header takes priority
+        clientConfigHeader: 'clientConfigHeader',
+      },
+    })
+      .post(endpointPath)
+      .query({siteId: 'site_id'})
+      .reply(200, responseBody);
+
+    const response = await runFetchHelper(url, options, clientConfig);
+    expect(response).toEqual(responseBody);
+  });
+
+  test('returns raw response when rawResponse flag is passed as true', async () => {
+    nock(basePath)
+      .post(endpointPath)
+      .query({siteId: 'site_id'})
+      .reply(200, responseBody);
+
+    const response = (await runFetchHelper(
+      url,
+      options,
+      clientConfig,
+      true
+    )) as Response;
+    expect(response instanceof Response).toBe(true);
+
+    const data = (await response.json()) as Record<string, string>;
+    expect(data).toEqual(responseBody);
+  });
+
+  test('throws error when clientConfig.throwOnBadResponse is true and fetch call fails', () => {
+    nock(basePath).post(endpointPath).query({siteId: 'site_id'}).reply(400);
+
+    const copyClientConfig = {...clientConfig, throwOnBadResponse: true};
+    expect(async () => {
+      await runFetchHelper(url, options, copyClientConfig);
+    })
+      .rejects.toThrow('400 Bad Request')
+      .finally(() => 'resolve promise');
+  });
+
+  test('returns data from response when rawResponse flag is passed as false or not passed', async () => {
+    nock(basePath).post(endpointPath).query(true).reply(200, responseBody);
+
+    const data = await runFetchHelper(url, options, clientConfig, false);
+    expect(data).toEqual(responseBody);
+  });
+
+  test('passes on fetchOptions from clientConfig to fetch call', async () => {
+    nock(basePath).post(endpointPath).query(true).reply(200, responseBody);
+
+    const spy = jest.spyOn(environment, 'fetch');
+    await runFetchHelper(url, options, clientConfig, false);
+    expect(spy).toBeCalledTimes(1);
+    expect(spy).toBeCalledWith(
+      expect.any(String),
+      expect.objectContaining(clientConfig.fetchOptions)
+    );
+  });
+});

--- a/src/static/helpers/fetchHelper.ts
+++ b/src/static/helpers/fetchHelper.ts
@@ -26,7 +26,7 @@ import {ClientConfigInit} from '../clientConfig';
  * @returns Raw response or data from response based on rawResponse argument from fetch call
  */
 // eslint-disable-next-line import/prefer-default-export
-export const runFetchHelper = async <Params extends BaseUriParameters>(
+export const doFetch = async <Params extends BaseUriParameters>(
   url: string,
   options?: {
     method?: string;

--- a/src/static/helpers/fetchHelper.ts
+++ b/src/static/helpers/fetchHelper.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import {BodyInit} from 'node-fetch';
 import {BaseUriParameters} from '.';
 import type {FetchOptions} from '../clientConfig';
 import ResponseError from '../responseError';
@@ -32,11 +33,7 @@ export const runFetchHelper = async <Params extends BaseUriParameters>(
     headers?: {
       authorization?: string;
     } & {[key: string]: string};
-    // TODO: probably need to fix this type
-    body?:
-      | {[key: string]: unknown}
-      | URLSearchParams
-      | (BodyInit & (BodyInit | null));
+    body?: BodyInit | unknown;
   },
   clientConfig?: ClientConfigInit<Params>,
   rawResponse?: boolean
@@ -49,8 +46,7 @@ export const runFetchHelper = async <Params extends BaseUriParameters>(
   const requestOptions: FetchOptions = {
     ...clientConfig?.fetchOptions,
     headers,
-    // TODO: probably need to fix this type
-    body: options?.body as unknown as FormData & URLSearchParams,
+    body: options?.body as BodyInit & string,
     method: options?.method ?? 'GET',
   };
 

--- a/src/static/helpers/fetchHelper.ts
+++ b/src/static/helpers/fetchHelper.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {BaseUriParameters} from '.';
+import type {FetchOptions} from '../clientConfig';
+import ResponseError from '../responseError';
+import {fetch} from './environment';
+import {ClientConfigInit} from '../clientConfig';
+
+/**
+ * A wrapper function around fetch designed for making requests using the SDK
+ * @param url - The url of the resource that you wish to fetch
+ * @param options? - An object containing any custom settings you want to apply to the request
+ * @param options.method? - The request HTTP operation. 'GET' is the default if no method is provided.
+ * @param options.headers? - Headers that are added to the request. Authorization header should be in this argument or in the clientConfig.headers
+ * @param options.body? - Body that is used for the request
+ * @param clientConfig? - Client Configuration object used by the SDK with properties that can affect the fetch call
+ * @param clientConfig.headers? - Additional headers that are added to the request. Authorization header should be in this argument or in the options?.headers. options?.headers will override any duplicate properties.
+ * @param clientConfig.fetchOptions? - fetchOptions that are passed onto the fetch request
+ * @param clientConfig.throwOnBadResponse? - flag that when set true will throw a response error if the fetch request fails
+ * @param rawResponse? - Flag to return the raw response from the fetch call. True for raw response object, false for the data from the response
+ * @returns Raw response or data from response based on rawResponse argument from fetch call
+ */
+// eslint-disable-next-line import/prefer-default-export
+export const runFetchHelper = async <Params extends BaseUriParameters>(
+  url: string,
+  options?: {
+    method?: string;
+    headers?: {
+      authorization?: string;
+    } & {[key: string]: string};
+    // TODO: probably need to fix this type
+    body?:
+      | {[key: string]: unknown}
+      | URLSearchParams
+      | (BodyInit & (BodyInit | null));
+  },
+  clientConfig?: ClientConfigInit<Params>,
+  rawResponse?: boolean
+): Promise<Response | unknown> => {
+  const headers: Record<string, string> = {
+    ...clientConfig?.headers,
+    ...options?.headers,
+  };
+
+  const requestOptions: FetchOptions = {
+    ...clientConfig?.fetchOptions,
+    headers,
+    // TODO: probably need to fix this type
+    ...(options?.body &&
+      ({body: options.body} as unknown as FormData & URLSearchParams)),
+    method: options?.method ?? 'GET',
+  };
+
+  const response = await fetch(url, requestOptions);
+  if (rawResponse) {
+    return response;
+  }
+  if (
+    clientConfig?.throwOnBadResponse &&
+    !response.ok &&
+    response.status !== 304
+  ) {
+    throw new ResponseError(response);
+  } else {
+    const text = await response.text();
+    // It's ideal to get "{}" for an empty response body, but we won't throw if it's truly empty
+    return (text ? JSON.parse(text) : {}) as unknown | Response;
+  }
+};

--- a/src/static/helpers/fetchHelper.ts
+++ b/src/static/helpers/fetchHelper.ts
@@ -50,8 +50,7 @@ export const runFetchHelper = async <Params extends BaseUriParameters>(
     ...clientConfig?.fetchOptions,
     headers,
     // TODO: probably need to fix this type
-    ...(options?.body &&
-      ({body: options.body} as unknown as FormData & URLSearchParams)),
+    body: options?.body as unknown as FormData & URLSearchParams,
     method: options?.method ?? 'GET',
   };
 

--- a/src/static/helpers/fetchHelper.ts
+++ b/src/static/helpers/fetchHelper.ts
@@ -33,7 +33,7 @@ export const doFetch = async <Params extends BaseUriParameters>(
     headers?: {
       authorization?: string;
     } & {[key: string]: string};
-    body?: BodyInit | unknown;
+    body?: BodyInit | globalThis.BodyInit | unknown;
   },
   clientConfig?: ClientConfigInit<Params>,
   rawResponse?: boolean
@@ -46,7 +46,7 @@ export const doFetch = async <Params extends BaseUriParameters>(
   const requestOptions: FetchOptions = {
     ...clientConfig?.fetchOptions,
     headers,
-    body: options?.body as BodyInit & string,
+    body: options?.body as (BodyInit & (globalThis.BodyInit | null)) | undefined,
     method: options?.method ?? 'GET',
   };
 

--- a/src/static/helpers/fetchHelper.ts
+++ b/src/static/helpers/fetchHelper.ts
@@ -46,7 +46,9 @@ export const doFetch = async <Params extends BaseUriParameters>(
   const requestOptions: FetchOptions = {
     ...clientConfig?.fetchOptions,
     headers,
-    body: options?.body as (BodyInit & (globalThis.BodyInit | null)) | undefined,
+    body: options?.body as
+      | (BodyInit & (globalThis.BodyInit | null))
+      | undefined,
     method: options?.method ?? 'GET',
   };
 

--- a/src/static/helpers/index.ts
+++ b/src/static/helpers/index.ts
@@ -9,3 +9,4 @@
 export * from './environment';
 export * from './slasHelper';
 export * from './types';
+export * from './customApi';

--- a/src/static/helpers/index.ts
+++ b/src/static/helpers/index.ts
@@ -10,3 +10,4 @@ export * from './environment';
 export * from './slasHelper';
 export * from './types';
 export * from './customApi';
+export * from './fetchHelper';

--- a/templates/client.ts.hbs
+++ b/templates/client.ts.hbs
@@ -1,6 +1,7 @@
 import ClientConfig, { ClientConfigInit } from "./clientConfig";
 // Must not import from ./helpers/index to avoid circular dependency via ShopperLogin
 import { isBrowser, fetch } from "./helpers/environment";
+import { runFetchHelper } from "./helpers";
 import type {
   BaseUriParameters,
   CompositeParameters,

--- a/templates/client.ts.hbs
+++ b/templates/client.ts.hbs
@@ -1,13 +1,12 @@
 import ClientConfig, { ClientConfigInit } from "./clientConfig";
 // Must not import from ./helpers/index to avoid circular dependency via ShopperLogin
-import { isBrowser, fetch } from "./helpers/environment";
+import { isBrowser } from "./helpers/environment";
 import { runFetchHelper } from "./helpers";
 import type {
   BaseUriParameters,
   CompositeParameters,
   RequireParametersUnlessAllAreOptional
 } from "./helpers/types";
-import ResponseError from "./responseError";
 import TemplateURL from "./templateUrl";
 import { USER_AGENT_HEADER, USER_AGENT_VALUE } from "./version";
 

--- a/templates/client.ts.hbs
+++ b/templates/client.ts.hbs
@@ -1,7 +1,7 @@
 import ClientConfig, { ClientConfigInit } from "./clientConfig";
 // Must not import from ./helpers/index to avoid circular dependency via ShopperLogin
 import { isBrowser } from "./helpers/environment";
-import { runFetchHelper } from "./helpers";
+import { doFetch } from "./helpers";
 import type {
   BaseUriParameters,
   CompositeParameters,

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -164,6 +164,16 @@
         }
       })
 
+      const url = new TemplateURL(
+        "{{{../path}}}",
+        this.clientConfig.baseUri,
+        {
+          pathParams,
+          queryParams,
+          origin: this.clientConfig.proxy
+        }
+      );
+
       const headers: Record<string, string> = {
         {{#if (isRequestWithPayload request)}}
         "Content-Type": "{{{getMediaTypeFromRequest request}}}",
@@ -172,26 +182,19 @@
         ...options?.headers
       };
 
-      const clientConfigCopy: ClientConfig<ConfigParameters> = {
-          ...this.clientConfig,
-          parameters: {
-            ...this.clientConfig.parameters,
-            ...pathParams
-          }
-      }
-      {{!-- if (!isBrowser) {
+      if (!isBrowser) {
         // Browsers forbid setting a custom user-agent header
         headers[USER_AGENT_HEADER] = [headers[USER_AGENT_HEADER], USER_AGENT_VALUE].join(" ");
-      } --}}
+      }
+
       const response = await runFetchHelper(
+        url.toString(),
         {
           method: "{{loud method}}",
-          parameters: queryParams,
-          path: "{{{../path}}}",
           headers,
           {{#if (isRequestWithPayload request)}}body: this.clientConfig.transformRequest(options.body, headers){{/if}}
         }, 
-        clientConfigCopy,
+        this.clientConfig,
         rawResponse
       )
 

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -197,10 +197,10 @@
 
       {{#if (eq (getReturnTypeFromOperation this) "void") }}
       if (rawResponse) {
-        return response;
+        return response as Response;
       }
       {{else}}
-      return response;
+      return response as Response | {{getReturnTypeFromOperation this}};
       {{/if}}
     }
   {{/each}}

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -187,7 +187,7 @@
         headers[USER_AGENT_HEADER] = [headers[USER_AGENT_HEADER], USER_AGENT_VALUE].join(" ");
       }
 
-      const response = await runFetchHelper(
+      const response = await doFetch(
         url.toString(),
         {
           method: "{{loud method}}",

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -164,17 +164,7 @@
         }
       })
 
-      {{!-- const url = new TemplateURL(
-        "{{{../path}}}",
-        this.clientConfig.baseUri,
-        {
-          pathParams,
-          queryParams,
-          origin: this.clientConfig.proxy
-        }
-      ); --}}
-
-      {{!-- const headers: Record<string, string> = {
+      const headers: Record<string, string> = {
         {{#if (isRequestWithPayload request)}}
         "Content-Type": "{{{getMediaTypeFromRequest request}}}",
         {{/if}}
@@ -182,45 +172,36 @@
         ...options?.headers
       };
 
-      if (!isBrowser) {
+      const clientConfigCopy: ClientConfig<ConfigParameters> = {
+          ...this.clientConfig,
+          parameters: {
+            ...this.clientConfig.parameters,
+            ...pathParams
+          }
+      }
+      {{!-- if (!isBrowser) {
         // Browsers forbid setting a custom user-agent header
         headers[USER_AGENT_HEADER] = [headers[USER_AGENT_HEADER], USER_AGENT_VALUE].join(" ");
       } --}}
+      const response = await runFetchHelper(
+        {
+          method: "{{loud method}}",
+          parameters: queryParams,
+          path: "{{{../path}}}",
+          headers,
+          {{#if (isRequestWithPayload request)}}body: this.clientConfig.transformRequest(options.body, headers){{/if}}
+        }, 
+        clientConfigCopy,
+        rawResponse
+      )
 
-      {{!-- const requestOptions = {
-        ...this.clientConfig.fetchOptions,
-        {{#if (isRequestWithPayload request)}}body: this.clientConfig.transformRequest(options.body, headers),{{/if}}
-        headers,
-        method: "{{loud method}}"
-      }; --}}
-
-      return runFetchHelper({
-        method: "{{loud method}}",
-        parameters: queryParams,
-        path: "{{{../path}}}",
-        headers: {
-          {{#if (isRequestWithPayload request)}}
-          "Content-Type": "{{{getMediaTypeFromRequest request}}}",
-          {{/if}}
-          ...options?.headers,
-        },
-        {{#if (isRequestWithPayload request)}}body: this.clientConfig.transformRequest(options.body, {...options?.headers, ...this.clientConfig?.headers}){{/if}}
-      }, this.clientConfig, rawResponse)
-      {{!-- const response = await fetch(url.toString(), requestOptions);
+      {{#if (eq (getReturnTypeFromOperation this) "void") }}
       if (rawResponse) {
         return response;
-      } else if (this.clientConfig.throwOnBadResponse && !response.ok && response.status !== 304) {
-        throw new ResponseError(response);
-      } --}}
-
-      // TODO: figure out a way to not return anything on void operations
-      {{#unless (eq (getReturnTypeFromOperation this) "void") }}
-        {{!-- else {
-          const text = await response.text();
-          // It's ideal to get "{}" for an empty response body, but we won't throw if it's truly empty
-          return text ? JSON.parse(text) : {};
-        } --}}
-      {{/unless}}
+      }
+      {{else}}
+      return response;
+      {{/if}}
     }
   {{/each}}
 {{/each}}

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -164,7 +164,7 @@
         }
       })
 
-      const url = new TemplateURL(
+      {{!-- const url = new TemplateURL(
         "{{{../path}}}",
         this.clientConfig.baseUri,
         {
@@ -172,9 +172,9 @@
           queryParams,
           origin: this.clientConfig.proxy
         }
-      );
+      ); --}}
 
-      const headers: Record<string, string> = {
+      {{!-- const headers: Record<string, string> = {
         {{#if (isRequestWithPayload request)}}
         "Content-Type": "{{{getMediaTypeFromRequest request}}}",
         {{/if}}
@@ -185,27 +185,41 @@
       if (!isBrowser) {
         // Browsers forbid setting a custom user-agent header
         headers[USER_AGENT_HEADER] = [headers[USER_AGENT_HEADER], USER_AGENT_VALUE].join(" ");
-      }
+      } --}}
 
-      const requestOptions = {
+      {{!-- const requestOptions = {
         ...this.clientConfig.fetchOptions,
         {{#if (isRequestWithPayload request)}}body: this.clientConfig.transformRequest(options.body, headers),{{/if}}
         headers,
         method: "{{loud method}}"
-      };
+      }; --}}
 
-      const response = await fetch(url.toString(), requestOptions);
+      return runFetchHelper({
+        method: "{{loud method}}",
+        parameters: queryParams,
+        path: "{{{../path}}}",
+        headers: {
+          {{#if (isRequestWithPayload request)}}
+          "Content-Type": "{{{getMediaTypeFromRequest request}}}",
+          {{/if}}
+          ...options?.headers,
+        },
+        {{#if (isRequestWithPayload request)}}body: this.clientConfig.transformRequest(options.body, {...options?.headers, ...this.clientConfig?.headers}){{/if}}
+      }, this.clientConfig, rawResponse)
+      {{!-- const response = await fetch(url.toString(), requestOptions);
       if (rawResponse) {
         return response;
       } else if (this.clientConfig.throwOnBadResponse && !response.ok && response.status !== 304) {
         throw new ResponseError(response);
-      }
+      } --}}
+
+      // TODO: figure out a way to not return anything on void operations
       {{#unless (eq (getReturnTypeFromOperation this) "void") }}
-        else {
+        {{!-- else {
           const text = await response.text();
           // It's ideal to get "{}" for an empty response body, but we won't throw if it's truly empty
           return text ? JSON.parse(text) : {};
-        }
+        } --}}
       {{/unless}}
     }
   {{/each}}


### PR DESCRIPTION
This PR adds support for custom APIs by exposing a helper function called `callCustomEndpoint` that allows users to call their custom API following common SDK patterns. This PR also pulls out some of the reused logic in `operations.ts.hbs` for fetching data and puts into a helper function called `doFetch`.

Some features of the `callCustomEndpoint` helper:
1. Defaults `apiVersion` to `v1` if not provided
2. Defaults `content-type` header to `application/json` if not provided 

Below is a sample script I used for testing the `callCustomEndpoint` helper function. Reach out to me for instructions on how to run this with the proper credentials.

```javascript
import pkg from 'commerce-sdk-isomorphic';
const { helpers } = pkg;

// replace client credentials
const CLIENT_ID = "clientId";
const ORG_ID = "orgId";
const SHORT_CODE = "shortCode";
const SITE_ID = "siteId";

// client configuration parameters
const clientConfig = {
  parameters: {
    clientId: CLIENT_ID,
    organizationId: ORG_ID,
    shortCode: SHORT_CODE,
    siteId: SITE_ID,
    endpointPath: 'greeting',
    apiName: 'e2e-tests',
    apiVersion: 'v1',
  },
  // proxy: 'http://localhost:8888/mobify/proxy/api'
  // baseUri: 'https://{shortCode}.alternativeBaseUri.com/custom/{apiName}/{apiVersion}'
};

const access_token = "<INSERT_ACCESS_TOKEN>"

let response = await helpers.callCustomEndpoint({
    method: 'GET',
    headers: {
        'Content-Type': 'application/json',
        authorization: `Bearer ${access_token}`
    }
}, clientConfig, false)

console.log('RESPONSE: ', response)

```

Resulting fetch request URLs:
1. No proxy/baseUri: `https://shortcode.api.commercecloud.salesforce.com/custom/e2e-tests/v1/organizations/orgId/greeting?siteId=siteId`
4. With Proxy: `http://localhost:8888/mobify/proxy/api/custom/e2e-tests/v1/organizations/orgId/greeting?siteId=siteId`
5. With baseUri: `https://shortcode.alternativebaseuri.com/custom/e2e-tests/v1/organizations/orgId/greeting?siteId=siteId`