### PR TITLE
@W-15248536@ - [v3] Google Search Console fix createCodeVerifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add helper function `callCustomEndpoint` to call [Custom APIs](https://developer.salesforce.com/docs/commerce/commerce-api/guide/custom-apis.html) - [#149](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/149)
 
+#### Bug fixes
+
+- Fixed createCodeVerifier adding entropy to be successfully indexed by Google Search Console [#150](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/150)
+
 ## v1.13.1
 
 #### Bug fixes

--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
   },
   "dependencies": {
     "nanoid": "^3.3.4",
-    "node-fetch": "2.6.12"
+    "node-fetch": "2.6.12",
+    "seedrandom": "^3.0.5"
   },
   "devDependencies": {
     "@babel/cli": "7.18.6",
@@ -117,6 +118,7 @@
     "@types/handlebars-helpers": "^0.5.3",
     "@types/node-fetch": "^2.6.2",
     "@types/react-dom": "^16.9.16",
+    "@types/seedrandom": "^3.0.8",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "autoprefixer": "9.8.8",
@@ -179,7 +181,7 @@
     },
     {
       "path": "commerce-sdk-isomorphic-with-deps.tgz",
-      "maxSize": "350 kB"
+      "maxSize": "400 kB"
     }
   ],
   "proxy": "https://SHORTCODE.api.commercecloud.salesforce.com"

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
   "bundlesize": [
     {
       "path": "lib/**/*.js",
-      "maxSize": "45 kB"
+      "maxSize": "46 kB"
     },
     {
       "path": "commerce-sdk-isomorphic-with-deps.tgz",

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -5,8 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {nanoid} from 'nanoid';
-
+import {customRandom, urlAlphabet} from 'nanoid';
+import seedrandom, {PRNG} from 'seedrandom';
 import {isBrowser} from './environment';
 
 import {
@@ -39,11 +39,18 @@ export const getCodeAndUsidFromUrl = (
   };
 };
 
+const nanoid = (): string => {
+  const rng: PRNG = seedrandom(String(+new Date()), {entropy: true});
+  return customRandom(urlAlphabet, 128, size =>
+    new Uint8Array(size).map(() => 256 * rng())
+  )();
+};
+
 /**
  * Creates a random string to use as a code verifier. This code is created by the client and sent with both the authorization request (as a code challenge) and the token request.
  * @returns code verifier
  */
-export const createCodeVerifier = (): string => nanoid(128);
+export const createCodeVerifier = (): string => nanoid();
 
 /**
  * Encodes a code verifier to a code challenge to send to the authorization endpoint

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -39,6 +39,10 @@ export const getCodeAndUsidFromUrl = (
   };
 };
 
+/**
+ * Adds entropy to nanoid() using seedrandom to ensure that the code_challenge sent to SCAPI by Google's crawler browser is unique.
+ * Solves the issue with Google's crawler getting the same result from nanoid() in two different runs, which results in the same PKCE code_challenge being used twice.
+ */
 const nanoid = (): string => {
   const rng: PRNG = seedrandom(String(+new Date()), {entropy: true});
   return customRandom(urlAlphabet, 128, size =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3651,6 +3651,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+"@types/seedrandom@^3.0.8":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-3.0.8.tgz#61cc8ed88f93a3c31289c295e6df8ca40be42bdf"
+  integrity sha512-TY1eezMU2zH2ozQoAFAQFOPpvP15g+ZgSfTZt31AUUH/Rxtnz3H+A/Sv1Snw2/amp//omibc+AEkTaA8KUeOLQ==
+
 "@types/semver@^7.3.4", "@types/semver@^7.3.9":
   version "7.3.10"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.10.tgz#5f19ee40cbeff87d916eedc8c2bfe2305d957f73"
@@ -14789,6 +14794,11 @@ scss-parser@^1.0.4:
   integrity sha512-RZOtvCmCnwkDo7kdcYBi807Y5EoTIxJ34AgEgJNDmOH1jl0/xG0FyYZFbH6Ga3Iwu7q8LSdxJ4C5UkzNXjQxKQ==
   dependencies:
     invariant "2.2.4"
+
+seedrandom@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
+  integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
 
 select-hose@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
**Problem**
When Google crawler calls[ createCodeVerifier()](https://github.com/SalesforceCommerceCloud/pwa-kit/blob/37c932ec02d83fe7961ed1b9cb8717eea9952434/packages/template-retail-react-app/app/commerce-api/pkce.js#L22) to create the code verifier we use for the PKCE authentication flow, the result from nanoid() is the same in two different runs.  This causes the same generated code_challenge to be used twice thus Google crawler gets the error stating that the PKCE code_challenge must be unique error.

The root of this issue is the fact that Googlebot’s implementation of random() is deterministic, meaning that it won’t produce unique random values from one string of runs to the next.

The result is that Google crawler indexes the error page instead of the proper page.

**Solution**
Add entropy to nanoid() using the library `seedrandom` to avoid duplicated code_challenge sent to SCAPI by Google crawler browser. 

Nanoid docs on [Custom Random Bytes Generator](https://github.com/ai/nanoid?tab=readme-ov-file#custom-random-bytes-generator).

**How to Test-Drive  This PR**

1. Follow the steps to reproduce in the quip doc: https://salesforce.quip.com/U1k5A2fXzpym#temp:C:DXJd70645fbe1a44e999dff07b74
2. Verify Google Search Console can successfully index the indicated URLs.
