### PR TITLE
Expo-Crypto for RN

### DIFF
--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -93,10 +93,15 @@ export const generateCodeChallenge = async (
       typeof navigator !== 'undefined' &&
       navigator.product === 'ReactNative'
     ) {
-      challenge =
-        (await crypto.digestStringAsync?.('SHA-256', codeVerifier, {
+      const base64Digest = await crypto.digestStringAsync?.(
+        'SHA-256',
+        codeVerifier,
+        {
           encoding: 'base64',
-        })) || '';
+        }
+      );
+
+      challenge = base64Digest ? urlSafe(base64Digest) : '';
     } else {
       challenge = urlSafe(
         crypto.default


### PR DESCRIPTION
For RN there is not a Crypto library.

So we should use expo-crypto and make an alias to crypto

## RN Config

# Install [Bable Module Resolver](https://www.npmjs.com/package/babel-plugin-module-resolver)
# Update babel.config.js
`module.exports = function (api) {
  api.cache(true);
  return {
    presets: ["babel-preset-expo"],
    plugins: [
      [
        "module-resolver",
        {
          alias: {
            crypto: "expo-crypto",
          },
        },
      ],
    ],
  };
};
`

So we are telling to RN that the crypto lib is expo-crypto insted of crypto, the fact is expo-crypto has different methods, so we need to verify if is RN or Brower/Node then if is react native call the methods from expo.

There is an issue, navigator.product its depreacted, but other that this config works as expect and all test passed 