### PR TITLE
Export parameter keys (@W-15676813@)

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,11 +177,11 @@
   "bundlesize": [
     {
       "path": "lib/**/*.js",
-      "maxSize": "46 kB"
+      "maxSize": "48 kB"
     },
     {
       "path": "commerce-sdk-isomorphic-with-deps.tgz",
-      "maxSize": "400 kB"
+      "maxSize": "415 kB"
     }
   ],
   "proxy": "https://SHORTCODE.api.commercecloud.salesforce.com"

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -46,6 +46,10 @@ export function registerPartials(): void {
     'operationsPartial',
     path.join(TEMPLATE_DIRECTORY, 'operations.ts.hbs')
   );
+  registerPartial(
+    'paramKeysPartial',
+    path.join(TEMPLATE_DIRECTORY, 'paramKeys.ts.hbs')
+  );
 }
 
 function addTemplates(apis: ApiMetadata, outputBasePath: string): ApiMetadata {

--- a/templates/client.ts.hbs
+++ b/templates/client.ts.hbs
@@ -110,3 +110,5 @@ const throwMissingRequiredParamError = ({name, paramType}: {name: string, paramT
 const warnInvalidParam = ({paramName, methodName}: {paramName: string, methodName: string}) => {
   console.warn(`Invalid Parameter for ${methodName}: ${paramName}`)
 }
+
+{{> paramKeysPartial model}}

--- a/templates/client.ts.hbs
+++ b/templates/client.ts.hbs
@@ -80,12 +80,12 @@ export type {{name.upperCamelCase}}Parameters = {{name.upperCamelCase}}PathParam
 *
 * <span style="font-size:.7em; display:block; text-align: right">
 * API Version: {{metadata.version}}<br />
-* Last Updated: {{metadata.updatedDate}}<br />  
+* Last Updated: {{metadata.updatedDate}}<br />
 * </span>
 {{#if (eq (lowercase metadata.categories.[CC Version Status].[0]) "beta")}}
-* @beta 
+* @beta
 * {{/if}}
-* 
+*
 
 */
 export class {{name.upperCamelCase}}<ConfigParameters extends {{{name.upperCamelCase}}}Parameters & Record<string, unknown>> {
@@ -102,5 +102,11 @@ export class {{name.upperCamelCase}}<ConfigParameters extends {{{name.upperCamel
   }
 
   {{> operationsPartial model}}
+}
 
+const throwMissingRequiredParamError = ({name, paramType}: {name: string, paramType: 'query' | 'path'}) => {
+  throw new Error(`Missing required ${paramType} parameter: ${name}`);
+}
+const warnInvalidParam = ({paramName, methodName}: {paramName: string, methodName: string}) => {
+  console.warn(`Invalid Parameter for ${methodName}: ${paramName}`)
 }

--- a/templates/index.ts.hbs
+++ b/templates/index.ts.hbs
@@ -1,5 +1,5 @@
 {{#each children}}
-export { {{name.upperCamelCase}} } from "./{{name.lowerCamelCase}}";
+export { {{name.upperCamelCase}}, paramKeys as {{name.upperCamelCase}}ParamKeys } from "./{{name.lowerCamelCase}}";
 import type * as {{name.upperCamelCase}}Types from "./{{name.lowerCamelCase}}";
 export type { {{name.upperCamelCase}}Types };
 {{/each}}

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -1,5 +1,6 @@
 {{#each encodes.endPoints}}
   {{#each operations}}
+
     static readonly {{{name}}}ParamKeys = [
       {{#each ../parameters}}
       '{{{name}}}',

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -155,7 +155,7 @@
         shortCode: configParams.shortCode,
         version: configParams.version || "v1"
       };
-      // TODO
+      // TODO: try extracting this
       {{{@root.name.upperCamelCase}}}.{{{name}}}PathParamKeys.forEach((paramKey) => {
         const value = optionParams[paramKey] ?? configParams[paramKey];
 
@@ -170,7 +170,7 @@
       });
 
       const queryParams: {{{@root.name.upperCamelCase}}}QueryParameters & { [key in `c_${string}`]: any } = {};
-      // TODO
+      // TODO: try extracting this
       {{{@root.name.upperCamelCase}}}.{{{name}}}QueryParamKeys.forEach((paramKey) => {
         const value = optionParams[paramKey] ?? configParams[paramKey];
 
@@ -186,6 +186,7 @@
         }
       });
 
+      // TODO: try extracting this
       Object.keys(optionParams).forEach((key) => {
         if(key.startsWith('c_') && optionParams[key as keyof typeof optionParams] !== undefined) {
           queryParams[key as keyof typeof queryParams] = optionParams[key as keyof typeof optionParams]

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -1,31 +1,6 @@
 {{#each encodes.endPoints}}
   {{#each operations}}
 
-    static readonly {{{name}}}PathParamKeys = [
-      {{#each ../parameters}}
-      '{{{name}}}',
-      {{/each}}
-    ] as const;
-    static readonly {{{name}}}QueryParamKeys = [
-      {{#each request.queryParameters}}
-      '{{{name}}}',
-      {{/each}}
-    ] as const;
-    static readonly {{{name}}}ParamKeys = [
-      ...{{{@root.name.upperCamelCase}}}.{{{name}}}PathParamKeys,
-      ...{{{@root.name.upperCamelCase}}}.{{{name}}}QueryParamKeys,
-    ] as const;
-    static readonly {{{name}}}ParamKeysRequired = [
-      {{#each ../parameters}}
-      '{{{name}}}',
-      {{/each}}
-      {{#each request.queryParameters}}
-      {{#if (is required "true")}}
-      '{{{name}}}',
-      {{/if}}
-      {{/each}}
-    ] as const;
-
     /**
     * {{{formatForTsDoc description}}}
     *
@@ -156,13 +131,13 @@
         version: configParams.version || "v1"
       };
       // TODO: try extracting this
-      {{{@root.name.upperCamelCase}}}.{{{name}}}PathParamKeys.forEach((paramKey) => {
+      {{{name}}}PathParamKeys.forEach((paramKey) => {
         const value = optionParams[paramKey] ?? configParams[paramKey];
 
         if (value !== undefined) {
           pathParams[paramKey] = value;
         } else {
-          const isRequired = {{{@root.name.upperCamelCase}}}.{{{name}}}ParamKeysRequired.includes(paramKey);
+          const isRequired = {{{name}}}ParamKeysRequired.includes(paramKey);
           if (isRequired) {
             throwMissingRequiredParamError({name: paramKey, paramType: 'path'})
           }
@@ -171,7 +146,7 @@
 
       const queryParams: {{{@root.name.upperCamelCase}}}QueryParameters & { [key in `c_${string}`]: any } = {};
       // TODO: try extracting this
-      {{{@root.name.upperCamelCase}}}.{{{name}}}QueryParamKeys.forEach((paramKey) => {
+      {{{name}}}QueryParamKeys.forEach((paramKey) => {
         const value = optionParams[paramKey] ?? configParams[paramKey];
 
         if (value !== undefined) {
@@ -179,7 +154,7 @@
           queryParams[paramKey] = value;
         } else {
           // @ts-ignore
-          const isRequired = {{{@root.name.upperCamelCase}}}.{{{name}}}ParamKeysRequired.includes(paramKey);
+          const isRequired = {{{name}}}ParamKeysRequired.includes(paramKey);
           if (isRequired) {
             throwMissingRequiredParamError({name: paramKey, paramType: 'query'})
           }

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -1,5 +1,25 @@
 {{#each encodes.endPoints}}
   {{#each operations}}
+    static readonly {{{name}}}ParamKeys = [
+      {{#each ../parameters}}
+      '{{{name}}}',
+      {{/each}}
+      {{#each request.queryParameters}}
+      '{{{name}}}',
+      {{/each}}
+    ] as const;
+
+    static readonly {{{name}}}ParamKeysRequired = [
+      {{#each ../parameters}}
+      '{{{name}}}',
+      {{/each}}
+      {{#each request.queryParameters}}
+      {{#if (is required "true")}}
+      '{{{name}}}',
+      {{/if}}
+      {{/each}}
+    ] as const;
+
     /**
     * {{{formatForTsDoc description}}}
     *
@@ -193,7 +213,7 @@
           method: "{{loud method}}",
           headers,
           {{#if (isRequestWithPayload request)}}body: this.clientConfig.transformRequest(options.body, headers){{/if}}
-        }, 
+        },
         this.clientConfig,
         rawResponse
       )

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -175,8 +175,10 @@
         const value = optionParams[paramKey] ?? configParams[paramKey];
 
         if (value !== undefined) {
+          // @ts-ignore
           queryParams[paramKey] = value;
         } else {
+          // @ts-ignore
           const isRequired = {{{@root.name.upperCamelCase}}}.{{{name}}}ParamKeysRequired.includes(paramKey);
           if (isRequired) {
             throw new Error(`Missing required query parameter: ${paramKey}`);

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -130,7 +130,6 @@
         shortCode: configParams.shortCode,
         version: configParams.version || "v1"
       };
-      // TODO: try extracting this
       {{{name}}}PathParamKeys.forEach((paramKey) => {
         const value = optionParams[paramKey] ?? configParams[paramKey];
 
@@ -145,7 +144,6 @@
       });
 
       const queryParams: {{{@root.name.upperCamelCase}}}QueryParameters & { [key in `c_${string}`]: any } = {};
-      // TODO: try extracting this
       {{{name}}}QueryParamKeys.forEach((paramKey) => {
         const value = optionParams[paramKey] ?? configParams[paramKey];
 
@@ -161,7 +159,6 @@
         }
       });
 
-      // TODO: try extracting this
       Object.keys(optionParams).forEach((key) => {
         if(key.startsWith('c_') && optionParams[key as keyof typeof optionParams] !== undefined) {
           queryParams[key as keyof typeof queryParams] = optionParams[key as keyof typeof optionParams]

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -164,7 +164,7 @@
         } else {
           const isRequired = {{{@root.name.upperCamelCase}}}.{{{name}}}ParamKeysRequired.includes(paramKey);
           if (isRequired) {
-            throw new Error(`Missing required path parameter: ${paramKey}`);
+            throwMissingRequiredParamError({name: paramKey, paramType: 'path'})
           }
         }
       });
@@ -181,7 +181,7 @@
           // @ts-ignore
           const isRequired = {{{@root.name.upperCamelCase}}}.{{{name}}}ParamKeysRequired.includes(paramKey);
           if (isRequired) {
-            throw new Error(`Missing required query parameter: ${paramKey}`);
+            throwMissingRequiredParamError({name: paramKey, paramType: 'query'})
           }
         }
       });
@@ -191,7 +191,7 @@
         if(key.startsWith('c_') && optionParams[key as keyof typeof optionParams] !== undefined) {
           queryParams[key as keyof typeof queryParams] = optionParams[key as keyof typeof optionParams]
         } else if(!queryParams.hasOwnProperty(key) && !pathParams.hasOwnProperty(key)) {
-          console.warn(`Invalid Parameter for {{{name}}}: ${key}`)
+          warnInvalidParam({ paramName: key, methodName: '{{{name}}}' })
         }
       })
 

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -1,15 +1,20 @@
 {{#each encodes.endPoints}}
   {{#each operations}}
 
-    static readonly {{{name}}}ParamKeys = [
+    static readonly {{{name}}}PathParamKeys = [
       {{#each ../parameters}}
       '{{{name}}}',
       {{/each}}
+    ] as const;
+    static readonly {{{name}}}QueryParamKeys = [
       {{#each request.queryParameters}}
       '{{{name}}}',
       {{/each}}
     ] as const;
-
+    static readonly {{{name}}}ParamKeys = [
+      ...{{{@root.name.upperCamelCase}}}.{{{name}}}PathParamKeys,
+      ...{{{@root.name.upperCamelCase}}}.{{{name}}}QueryParamKeys,
+    ] as const;
     static readonly {{{name}}}ParamKeysRequired = [
       {{#each ../parameters}}
       '{{{name}}}',
@@ -150,32 +155,34 @@
         shortCode: configParams.shortCode,
         version: configParams.version || "v1"
       };
-      {{#each ../parameters}}
-      if (optionParams["{{{name}}}"] !== undefined) {
-        pathParams["{{{name}}}"] = optionParams["{{{name}}}"];
-      } else if (configParams["{{{name}}}"] !== undefined) {
-        pathParams["{{{name}}}"] = configParams["{{{name}}}"];
-      }
-      {{#if (is required "true")}}
-      else {
-        throw new Error('Missing required path parameter: {{{name}}}');
-      }
-      {{/if}}
-      {{/each}}
+      // TODO
+      {{{@root.name.upperCamelCase}}}.{{{name}}}PathParamKeys.forEach((paramKey) => {
+        const value = optionParams[paramKey] ?? configParams[paramKey];
+
+        if (value !== undefined) {
+          pathParams[paramKey] = value;
+        } else {
+          const isRequired = {{{@root.name.upperCamelCase}}}.{{{name}}}ParamKeysRequired.includes(paramKey);
+          if (isRequired) {
+            throw new Error(`Missing required path parameter: ${paramKey}`);
+          }
+        }
+      });
 
       const queryParams: {{{@root.name.upperCamelCase}}}QueryParameters & { [key in `c_${string}`]: any } = {};
-      {{#each request.queryParameters}}
-      if (optionParams["{{{name}}}"] !== undefined) {
-        queryParams["{{{name}}}"] = optionParams["{{{name}}}"];
-      } else if (configParams["{{{name}}}"] !== undefined) {
-        queryParams["{{{name}}}"] = configParams["{{{name}}}"];
-      }
-      {{#if (is required "true")}}
-      else {
-        throw new Error('Missing required query parameter: {{{name}}}');
-      }
-      {{/if}}
-      {{/each}}
+      // TODO
+      {{{@root.name.upperCamelCase}}}.{{{name}}}QueryParamKeys.forEach((paramKey) => {
+        const value = optionParams[paramKey] ?? configParams[paramKey];
+
+        if (value !== undefined) {
+          queryParams[paramKey] = value;
+        } else {
+          const isRequired = {{{@root.name.upperCamelCase}}}.{{{name}}}ParamKeysRequired.includes(paramKey);
+          if (isRequired) {
+            throw new Error(`Missing required query parameter: ${paramKey}`);
+          }
+        }
+      });
 
       Object.keys(optionParams).forEach((key) => {
         if(key.startsWith('c_') && optionParams[key as keyof typeof optionParams] !== undefined) {

--- a/templates/paramKeys.ts.hbs
+++ b/templates/paramKeys.ts.hbs
@@ -1,0 +1,41 @@
+{{#each encodes.endPoints}}
+  {{#each operations}}
+
+    const {{{name}}}PathParamKeys = [
+      {{#each ../parameters}}
+      '{{{name}}}',
+      {{/each}}
+    ] as const;
+    const {{{name}}}QueryParamKeys = [
+      {{#each request.queryParameters}}
+      '{{{name}}}',
+      {{/each}}
+    ] as const;
+    const {{{name}}}ParamKeys = [
+      ...{{{name}}}PathParamKeys,
+      ...{{{name}}}QueryParamKeys,
+    ] as const;
+    const {{{name}}}ParamKeysRequired = [
+      {{#each ../parameters}}
+      '{{{name}}}',
+      {{/each}}
+      {{#each request.queryParameters}}
+      {{#if (is required "true")}}
+      '{{{name}}}',
+      {{/if}}
+      {{/each}}
+    ] as const;
+
+  {{/each}}
+{{/each}}
+
+export const paramKeys = {
+  {{#each encodes.endPoints}}
+  {{#each operations}}
+  {{{name}}}: {{{name}}}ParamKeys,
+  {{{name}}}Path: {{{name}}}PathParamKeys,
+  {{{name}}}Query: {{{name}}}QueryParamKeys,
+  {{{name}}}Required: {{{name}}}ParamKeysRequired,
+  {{/each}}
+  {{/each}}
+}


### PR DESCRIPTION
This PR exports the parameter keys for each API method, so that a client like `commerce-sdk-react` will be able to rely on them (and no longer hardcoding those param keys).

For an example on how to consume the exported parameter keys, please see https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1812

Note: this PR is for the parameter _keys_ (not its Typescript types). So we're exporting the list/array.

## How to test-drive
In this case, I worked with 2 separate repos: this commerce-sdk-isomorphic (exports the parameter keys) and the pwa-kit (to consume those keys). 

So first of all, let's build the commerce-sdk-isomorphic to get its minified output:
1. `yarn install`
2. `yarn run renderTemplates`
3. `yarn run build:lib`
4. If you need more details: https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/blob/export-parameter-keys/Contributing.md

Once we've gotten those minified scripts, we need to somehow use them in the pwa-kit repo. I've tried `npm link` but gotten an error. I'm not sure how to `npm link` properly within a monorepo like ours. Anyways, I manually created a symlink instead, like this:
1. Switch to the pwa-kit repo and check out this sample PR: https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1812
2. Create symlink from commerce-sdk-react
```bash
	# From "pwa-kit/packages/commerce-sdk-react"
	rm -r node_modules/commerce-sdk-isomorphic/lib
	ln -s ~/repos/commerce-sdk-isomorphic/lib node_modules/commerce-sdk-isomorphic
```
3. Now in your code editor, open the file "packages/commerce-sdk-react/src/hooks/ShopperProducts/query.ts".
4. Inspect the values of some variables, and you'll see the parameter keys like this:

![iTerm2 2024-06-04 at 11 04 02](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/assets/847300/7369660d-5fe0-4de6-a6ab-6f518b39b00d)

![iTerm2 2024-06-04 at 11 04 43](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/assets/847300/0172ba1f-4c37-421f-8c03-890d7febd4d4)
