### PR TITLE
Export parameter keys (@W-15676813@)

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,11 +177,11 @@
   "bundlesize": [
     {
       "path": "lib/**/*.js",
-      "maxSize": "46 kB"
+      "maxSize": "48 kB"
     },
     {
       "path": "commerce-sdk-isomorphic-with-deps.tgz",
-      "maxSize": "400 kB"
+      "maxSize": "415 kB"
     }
   ],
   "proxy": "https://SHORTCODE.api.commercecloud.salesforce.com"

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     },
     {
       "path": "commerce-sdk-isomorphic-with-deps.tgz",
-      "maxSize": "415 kB"
+      "maxSize": "410 kB"
     }
   ],
   "proxy": "https://SHORTCODE.api.commercecloud.salesforce.com"

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -46,6 +46,10 @@ export function registerPartials(): void {
     'operationsPartial',
     path.join(TEMPLATE_DIRECTORY, 'operations.ts.hbs')
   );
+  registerPartial(
+    'paramKeysPartial',
+    path.join(TEMPLATE_DIRECTORY, 'paramKeys.ts.hbs')
+  );
 }
 
 function addTemplates(apis: ApiMetadata, outputBasePath: string): ApiMetadata {

--- a/src/test/parameters.test.ts
+++ b/src/test/parameters.test.ts
@@ -25,6 +25,13 @@ describe('Parameters', () => {
       .reply(200, MOCK_RESPONSE)
   );
 
+  it('has a list of parameter keys (and the required ones)', () => {
+    // eslint-disable-next-line
+    expect(ShopperSearch.paramKeys?.productSearch).toBeDefined();
+    // eslint-disable-next-line
+    expect(ShopperSearch.paramKeys?.productSearchRequired).toBeDefined();
+  });
+
   it('can all be specified in config (no method parameters object)', async () => {
     const searchClient = new ShopperSearch({
       parameters: {

--- a/templates/client.ts.hbs
+++ b/templates/client.ts.hbs
@@ -80,13 +80,12 @@ export type {{name.upperCamelCase}}Parameters = {{name.upperCamelCase}}PathParam
 *
 * <span style="font-size:.7em; display:block; text-align: right">
 * API Version: {{metadata.version}}<br />
-* Last Updated: {{metadata.updatedDate}}<br />  
+* Last Updated: {{metadata.updatedDate}}<br />
 * </span>
-{{#if (eq (lowercase metadata.categories.[CC Version Status].[0]) "beta")}}
-* @beta 
+* {{#if (eq (lowercase metadata.categories.[CC Version Status].[0]) "beta")}}
+* @beta
 * {{/if}}
-* 
-
+*
 */
 export class {{name.upperCamelCase}}<ConfigParameters extends {{{name.upperCamelCase}}}Parameters & Record<string, unknown>> {
   // baseUri is not required on ClientConfig, but we know that we provide one in the class constructor
@@ -101,6 +100,6 @@ export class {{name.upperCamelCase}}<ConfigParameters extends {{{name.upperCamel
     this.clientConfig = new ClientConfig(cfg) as ClientConfig<ConfigParameters> & { baseUri: string };
   }
 
+  {{> paramKeysPartial model}}
   {{> operationsPartial model}}
-
 }

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -1,26 +1,6 @@
 {{#each encodes.endPoints}}
   {{#each operations}}
 
-    static readonly {{{name}}}ParamKeys = [
-      {{#each ../parameters}}
-      '{{{name}}}',
-      {{/each}}
-      {{#each request.queryParameters}}
-      '{{{name}}}',
-      {{/each}}
-    ] as const;
-
-    static readonly {{{name}}}ParamKeysRequired = [
-      {{#each ../parameters}}
-      '{{{name}}}',
-      {{/each}}
-      {{#each request.queryParameters}}
-      {{#if (is required "true")}}
-      '{{{name}}}',
-      {{/if}}
-      {{/each}}
-    ] as const;
-
     /**
     * {{{formatForTsDoc description}}}
     *

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -1,5 +1,6 @@
 {{#each encodes.endPoints}}
   {{#each operations}}
+
     static readonly {{{name}}}ParamKeys = [
       {{#each ../parameters}}
       '{{{name}}}',

--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -1,5 +1,25 @@
 {{#each encodes.endPoints}}
   {{#each operations}}
+    static readonly {{{name}}}ParamKeys = [
+      {{#each ../parameters}}
+      '{{{name}}}',
+      {{/each}}
+      {{#each request.queryParameters}}
+      '{{{name}}}',
+      {{/each}}
+    ] as const;
+
+    static readonly {{{name}}}ParamKeysRequired = [
+      {{#each ../parameters}}
+      '{{{name}}}',
+      {{/each}}
+      {{#each request.queryParameters}}
+      {{#if (is required "true")}}
+      '{{{name}}}',
+      {{/if}}
+      {{/each}}
+    ] as const;
+
     /**
     * {{{formatForTsDoc description}}}
     *
@@ -193,7 +213,7 @@
           method: "{{loud method}}",
           headers,
           {{#if (isRequestWithPayload request)}}body: this.clientConfig.transformRequest(options.body, headers){{/if}}
-        }, 
+        },
         this.clientConfig,
         rawResponse
       )

--- a/templates/paramKeys.ts.hbs
+++ b/templates/paramKeys.ts.hbs
@@ -1,0 +1,24 @@
+static readonly paramKeys = {
+  {{#each encodes.endPoints}}
+  {{#each operations}}
+  {{{name}}}: [
+    {{#each ../parameters}}
+    '{{{name}}}',
+    {{/each}}
+    {{#each request.queryParameters}}
+    '{{{name}}}',
+    {{/each}}
+  ] as const,
+  {{{name}}}Required: [
+    {{#each ../parameters}}
+    '{{{name}}}',
+    {{/each}}
+    {{#each request.queryParameters}}
+    {{#if (is required "true")}}
+    '{{{name}}}',
+    {{/if}}
+    {{/each}}
+  ] as const,
+  {{/each}}
+  {{/each}}
+};

--- a/templates/paramKeys.ts.hbs
+++ b/templates/paramKeys.ts.hbs
@@ -8,7 +8,7 @@ static readonly paramKeys = {
     {{#each request.queryParameters}}
     '{{{name}}}',
     {{/each}}
-  ] as const,
+  ],
   {{{name}}}Required: [
     {{#each ../parameters}}
     '{{{name}}}',
@@ -18,7 +18,7 @@ static readonly paramKeys = {
     '{{{name}}}',
     {{/if}}
     {{/each}}
-  ] as const,
+  ],
   {{/each}}
   {{/each}}
-};
+} as const;


### PR DESCRIPTION
This PR exports the parameter keys for each API method, so that a client like `commerce-sdk-react` will be able to rely on them (and no longer hardcoding those param keys).

For an example on how to consume the exported parameter keys, please see https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1812

Note: this PR is for the parameter _keys_ (not its Typescript types). So we're exporting the list/array.

Previous PR: #157 

## How to test-drive
In this case, I worked with 2 separate repos: this commerce-sdk-isomorphic (exports the parameter keys) and the pwa-kit (to consume those keys). 

So first of all, let's build the commerce-sdk-isomorphic to get its minified output:
1. `yarn install`
2. `yarn run renderTemplates`
3. `yarn run build:lib`
4. If you need more details: https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/blob/export-parameter-keys/Contributing.md

Once we've gotten those minified scripts, we need to somehow use them in the pwa-kit repo. I've tried `npm link` but gotten an error. I'm not sure how to `npm link` properly within a monorepo like ours. Anyways, I manually created a symlink instead, like this:
1. Switch to the pwa-kit repo and check out this sample PR: https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1812
2. Create symlink from commerce-sdk-react
```bash
	# From "pwa-kit/packages/commerce-sdk-react"
	rm -r node_modules/commerce-sdk-isomorphic/lib
	ln -s ~/repos/commerce-sdk-isomorphic/lib node_modules/commerce-sdk-isomorphic
```
3. Now in your code editor, open the file "packages/commerce-sdk-react/src/hooks/ShopperProducts/query.ts".
4. Inspect the values of some variables, and you'll see the parameter keys like this:

![iTerm2 2024-06-04 at 11 04 02](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/assets/847300/7369660d-5fe0-4de6-a6ab-6f518b39b00d)

![iTerm2 2024-06-04 at 11 04 43](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/assets/847300/0172ba1f-4c37-421f-8c03-890d7febd4d4)
