### PR TITLE
Update SLAS helper to require channel_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v3.0.0
+
+### Enchancements
+
+- Update SLAS helper function `loginGuestUserPrivate` to require `channel_id` [#165](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/165)
+
 ## v2.1.0
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## v3.0.0
 
+### :warning: Planned Shopper Context Changes :warning: 
+
+Starting July 31st 2024, all endpoints in the Shopper context API will require the `siteId` parameter for new customers. This field is marked as optional for backward compatibility and will be changed to mandatory tentatively by January 2025.
+
 ### Enchancements
 
-- Update SLAS helper function `loginGuestUserPrivate` to require `channel_id` [#165](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/165)
+- Update SLAS helper function `loginGuestUserPrivate` to require `channel_id` as SLAS requires `channel_id` when requesting a guest access token with a `grant_type` of `client_credentials` starting July 31st 2024 [#165](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/165)
+  - See the [announcement on the developer docs](https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas.html#guest-tokens) for more information
 
 ## v2.1.0
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This SDK provides a Browser & Node.js JavaScript client for calling [B2C Commerc
 
 _For a Node.js only SDK that can also access Admin APIs checkout [Commerce SDK](https://github.com/SalesforceCommerceCloud/commerce-sdk)._
 
+## :warning: Planned Shopper Context Changes :warning:
+
+Starting July 31st 2024, all endpoints in the Shopper context API will require the `siteId` parameter for new customers. This field is marked as optional for backward compatibility and will be changed to mandatory tentatively by January 2025.
+
 ## Getting Started
 
 ### Requirements

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -262,7 +262,33 @@ describe('Guest user flow', () => {
     expect(getAccessTokenMock).toBeCalledWith(expectedReqOptions);
     expect(accessToken).toBe(expectedTokenResponse);
   });
+
+  test('throws an error when channel_id is not passed into private client', async () => {
+    const mockSlasClient = createMockSlasClient();
+    const mockSlasClientNoSiteID = {
+      ...mockSlasClient,
+      clientConfig: {
+        parameters: {
+          ...mockSlasClient.clientConfig.parameters,
+          siteId: undefined, // siteId in client config is used for channel_id
+        },
+      },
+    };
+
+    await expect(
+      slasHelper.loginGuestUserPrivate(
+        // eslint-disable-next-line
+        // @ts-ignore
+        mockSlasClientNoSiteID,
+        parameters,
+        credentialsPrivate
+      )
+    ).rejects.toThrow(
+      'Required argument channel_id is not provided through clientConfig.parameters.siteId'
+    );
+  });
 });
+
 describe('Registered B2C user flow', () => {
   const expectedTokenBody = {
     body: {

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -255,6 +255,7 @@ describe('Guest user flow', () => {
       },
       body: {
         grant_type: 'client_credentials',
+        channel_id: 'site_id',
         usid: 'usid',
       },
     };

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -182,15 +182,15 @@ export async function loginGuestUserPrivate(
     clientSecret: string;
   }
 ): Promise<TokenResponse> {
-  const authorization = `Basic ${stringToBase64(
-    `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
-  )}`;
-
   if (!slasClient.clientConfig.parameters.siteId) {
     throw new Error(
       'Required argument channel_id is not provided through clientConfig.parameters.siteId'
     );
   }
+
+  const authorization = `Basic ${stringToBase64(
+    `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
+  )}`;
 
   const options = {
     headers: {

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -186,12 +186,19 @@ export async function loginGuestUserPrivate(
     `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
   )}`;
 
+  if (!slasClient.clientConfig.parameters.siteId) {
+    throw new Error(
+      'Required argument channel_id is not provided through clientConfig.parameters.siteId'
+    );
+  }
+
   const options = {
     headers: {
       Authorization: authorization,
     },
     body: {
       grant_type: 'client_credentials',
+      channel_id: slasClient.clientConfig.parameters.siteId,
       ...(parameters.usid && {usid: parameters.usid}),
     },
   };


### PR DESCRIPTION
Starting 7/31/2024, SLAS will start requiring the `channel_id` as a required argument when retrieving an access token with `grant_type: 'client_credentials` for security purposes. This PR updates the `loginGuestUserPrivate` SLAS helper function to require `channel_id`.