### PR TITLE
Add support for SLAS DNT (do not track) parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v3.1.0
+
+### Enhancements
+- Update SLAS helpers to support DNT parameter [#167](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/167)
+
 ## v3.0.0
 
 ### :warning: Planned API Changes :warning: 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "husky": {
     "hooks": {
+      "pre-commit": "lint-staged",
       "pre-push": "CI=true yarn test --passWithNoTests"
     }
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged",
       "pre-push": "CI=true yarn test --passWithNoTests"
     }
   },

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-/* eslint header/header: "off" */
+/* eslint header/header: "off", max-lines:"off" */
 /*
  * Copyright (c) 2022, salesforce.com, inc.
  * All rights reserved.
@@ -47,6 +47,7 @@ const parameters = {
   refreshToken: 'refresh_token',
   usid: 'usid',
   hint: 'hint',
+  dnt: 'true',
 };
 
 const url =
@@ -55,9 +56,7 @@ const url =
 const authenticateCustomerMock = jest.fn(() => ({url}));
 
 const getAccessTokenMock = jest.fn(() => expectedTokenResponse);
-
 const logoutCustomerMock = jest.fn(() => expectedTokenResponse);
-
 const generateCodeChallengeMock = jest.fn(() => 'code_challenge');
 
 const createMockSlasClient = () =>
@@ -220,6 +219,7 @@ describe('Guest user flow', () => {
         grant_type: 'authorization_code_pkce',
         redirect_uri: 'redirect_uri',
         usid: '048adcfb-aa93-4978-be9e-09cb569fdcb9',
+        dnt: 'true',
       },
     };
     const mockSlasClient = createMockSlasClient();
@@ -257,6 +257,7 @@ describe('Guest user flow', () => {
         grant_type: 'client_credentials',
         channel_id: 'site_id',
         usid: 'usid',
+        dnt: 'true',
       },
     };
     expect(getAccessTokenMock).toBeCalledWith(expectedReqOptions);
@@ -300,6 +301,7 @@ describe('Registered B2C user flow', () => {
       organizationId: 'organization_id',
       redirect_uri: 'redirect_uri',
       usid: '048adcfb-aa93-4978-be9e-09cb569fdcb9',
+      dnt: 'true',
     },
   };
 
@@ -338,6 +340,7 @@ describe('Registered B2C user flow', () => {
         channel_id: 'site_id',
         organizationId: 'organization_id',
         usid: '048adcfb-aa93-4978-be9e-09cb569fdcb9',
+        dnt: 'true',
       },
     };
     // slasClient is copied and tries to make an actual API call

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -47,7 +47,7 @@ const parameters = {
   refreshToken: 'refresh_token',
   usid: 'usid',
   hint: 'hint',
-  dnt: 'true',
+  dnt: true,
 };
 
 const url =
@@ -219,7 +219,7 @@ describe('Guest user flow', () => {
         grant_type: 'authorization_code_pkce',
         redirect_uri: 'redirect_uri',
         usid: '048adcfb-aa93-4978-be9e-09cb569fdcb9',
-        dnt: 'true',
+        dnt: true,
       },
     };
     const mockSlasClient = createMockSlasClient();
@@ -257,7 +257,7 @@ describe('Guest user flow', () => {
         grant_type: 'client_credentials',
         channel_id: 'site_id',
         usid: 'usid',
-        dnt: 'true',
+        dnt: true,
       },
     };
     expect(getAccessTokenMock).toBeCalledWith(expectedReqOptions);
@@ -301,7 +301,7 @@ describe('Registered B2C user flow', () => {
       organizationId: 'organization_id',
       redirect_uri: 'redirect_uri',
       usid: '048adcfb-aa93-4978-be9e-09cb569fdcb9',
-      dnt: 'true',
+      dnt: true,
     },
   };
 
@@ -340,7 +340,7 @@ describe('Registered B2C user flow', () => {
         channel_id: 'site_id',
         organizationId: 'organization_id',
         usid: '048adcfb-aa93-4978-be9e-09cb569fdcb9',
-        dnt: 'true',
+        dnt: true,
       },
     };
     // slasClient is copied and tries to make an actual API call

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -219,7 +219,7 @@ describe('Guest user flow', () => {
         grant_type: 'authorization_code_pkce',
         redirect_uri: 'redirect_uri',
         usid: '048adcfb-aa93-4978-be9e-09cb569fdcb9',
-        dnt: true,
+        dnt: 'true',
       },
     };
     const mockSlasClient = createMockSlasClient();
@@ -257,7 +257,7 @@ describe('Guest user flow', () => {
         grant_type: 'client_credentials',
         channel_id: 'site_id',
         usid: 'usid',
-        dnt: true,
+        dnt: 'true',
       },
     };
     expect(getAccessTokenMock).toBeCalledWith(expectedReqOptions);
@@ -301,7 +301,7 @@ describe('Registered B2C user flow', () => {
       organizationId: 'organization_id',
       redirect_uri: 'redirect_uri',
       usid: '048adcfb-aa93-4978-be9e-09cb569fdcb9',
-      dnt: true,
+      dnt: 'true',
     },
   };
 
@@ -340,7 +340,7 @@ describe('Registered B2C user flow', () => {
         channel_id: 'site_id',
         organizationId: 'organization_id',
         usid: '048adcfb-aa93-4978-be9e-09cb569fdcb9',
-        dnt: true,
+        dnt: 'true',
       },
     };
     // slasClient is copied and tries to make an actual API call

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -178,7 +178,7 @@ export async function loginGuestUserPrivate(
   }>,
   parameters: {
     usid?: string;
-    dnt?: string;
+    dnt?: boolean;
   },
   credentials: {
     clientSecret: string;
@@ -202,7 +202,7 @@ export async function loginGuestUserPrivate(
       grant_type: 'client_credentials',
       channel_id: slasClient.clientConfig.parameters.siteId,
       ...(parameters.usid && {usid: parameters.usid}),
-      ...(parameters.dnt && {dnt: parameters.dnt}),
+      ...(parameters.dnt && {dnt: parameters.dnt.toString()}),
     },
   };
 
@@ -228,7 +228,7 @@ export async function loginGuestUser(
   parameters: {
     redirectURI: string;
     usid?: string;
-    dnt?: string;
+    dnt?: boolean;
   }
 ): Promise<TokenResponse> {
   const codeVerifier = createCodeVerifier();
@@ -247,7 +247,7 @@ export async function loginGuestUser(
     grant_type: 'authorization_code_pkce',
     redirect_uri: parameters.redirectURI,
     usid: authResponse.usid,
-    ...(parameters.dnt && {dnt: parameters.dnt}),
+    ...(parameters.dnt && {dnt: parameters.dnt.toString()}),
   };
 
   return slasClient.getAccessToken({body: tokenBody});
@@ -282,7 +282,7 @@ export async function loginRegisteredUserB2C(
   parameters: {
     redirectURI: string;
     usid?: string;
-    dnt?: string;
+    dnt?: boolean;
   }
 ): Promise<TokenResponse> {
   const codeVerifier = createCodeVerifier();
@@ -339,7 +339,7 @@ export async function loginRegisteredUserB2C(
     organizationId: slasClient.clientConfig.parameters.organizationId,
     redirect_uri: parameters.redirectURI,
     usid: authResponse.usid,
-    ...(parameters.dnt && {dnt: parameters.dnt}),
+    ...(parameters.dnt && {dnt: parameters.dnt.toString()}),
   };
   // using slas private client
   if (credentials.clientSecret) {

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -166,6 +166,7 @@ export async function authorize(
  * @param credentials.clientSecret - secret associated with client ID
  * @param parameters - parameters to pass in the API calls.
  * @param parameters.usid? - Unique Shopper Identifier to enable personalization.
+ * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
  * @returns TokenResponse
  */
 export async function loginGuestUserPrivate(
@@ -177,6 +178,7 @@ export async function loginGuestUserPrivate(
   }>,
   parameters: {
     usid?: string;
+    dnt?: string;
   },
   credentials: {
     clientSecret: string;
@@ -200,6 +202,7 @@ export async function loginGuestUserPrivate(
       grant_type: 'client_credentials',
       channel_id: slasClient.clientConfig.parameters.siteId,
       ...(parameters.usid && {usid: parameters.usid}),
+      ...(parameters.dnt && {dnt: parameters.dnt}),
     },
   };
 
@@ -212,6 +215,7 @@ export async function loginGuestUserPrivate(
  * @param parameters - parameters to pass in the API calls.
  * @param parameters.redirectURI - Per OAuth standard, a valid app route. Must be listed in your SLAS configuration. On server, this will not be actually called. On browser, this will be called, but ignored.
  * @param parameters.usid? - Unique Shopper Identifier to enable personalization.
+ * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
  * @returns TokenResponse
  */
 export async function loginGuestUser(
@@ -224,6 +228,7 @@ export async function loginGuestUser(
   parameters: {
     redirectURI: string;
     usid?: string;
+    dnt?: string;
   }
 ): Promise<TokenResponse> {
   const codeVerifier = createCodeVerifier();
@@ -242,6 +247,7 @@ export async function loginGuestUser(
     grant_type: 'authorization_code_pkce',
     redirect_uri: parameters.redirectURI,
     usid: authResponse.usid,
+    ...(parameters.dnt && {dnt: parameters.dnt}),
   };
 
   return slasClient.getAccessToken({body: tokenBody});
@@ -258,6 +264,7 @@ export async function loginGuestUser(
  * @param parameters - parameters to pass in the API calls.
  * @param parameters.redirectURI - Per OAuth standard, a valid app route. Must be listed in your SLAS configuration. On server, this will not be actually called. On browser, this will be called, but ignored.
  * @param parameters.usid? - Unique Shopper Identifier to enable personalization.
+ * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
  * @returns TokenResponse
  */
 export async function loginRegisteredUserB2C(
@@ -275,6 +282,7 @@ export async function loginRegisteredUserB2C(
   parameters: {
     redirectURI: string;
     usid?: string;
+    dnt?: string;
   }
 ): Promise<TokenResponse> {
   const codeVerifier = createCodeVerifier();
@@ -331,6 +339,7 @@ export async function loginRegisteredUserB2C(
     organizationId: slasClient.clientConfig.parameters.organizationId,
     redirect_uri: parameters.redirectURI,
     usid: authResponse.usid,
+    ...(parameters.dnt && {dnt: parameters.dnt}),
   };
   // using slas private client
   if (credentials.clientSecret) {


### PR DESCRIPTION
This PR adds a new optional parameter `dnt` to SLAS helpers: `loginGuestUserPrivate`, `loginGuestUser` and `loginRegisteredUserB2C`