### PR TITLE
Add dnt parameter to SLAS refresh token helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     },
     {
       "path": "commerce-sdk-isomorphic-with-deps.tgz",
-      "maxSize": "425 kB"
+      "maxSize": "430 kB"
     }
   ],
   "proxy": "https://SHORTCODE.api.commercecloud.salesforce.com"

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -443,6 +443,7 @@ describe('Refresh Token', () => {
         channel_id: 'site_id',
         grant_type: 'refresh_token',
         refresh_token: 'refresh_token',
+        dnt: 'true',
       },
     };
     const token = slasHelper.refreshAccessToken(
@@ -465,6 +466,7 @@ describe('Refresh Token', () => {
         client_id: 'client_id',
         channel_id: 'site_id',
         refresh_token: parameters.refreshToken,
+        dnt: 'true',
       },
     };
     const token = slasHelper.refreshAccessToken(

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -376,7 +376,10 @@ export function refreshAccessToken(
     clientId: string;
     siteId: string;
   }>,
-  parameters: {refreshToken: string},
+  parameters: {
+    refreshToken: string;
+    dnt?: boolean;
+  },
   credentials?: {clientSecret?: string}
 ): Promise<TokenResponse> {
   const body = {
@@ -384,6 +387,7 @@ export function refreshAccessToken(
     refresh_token: parameters.refreshToken,
     client_id: slasClient.clientConfig.parameters.clientId,
     channel_id: slasClient.clientConfig.parameters.siteId,
+    ...(parameters.dnt && {dnt: parameters.dnt.toString()}),
   };
 
   if (credentials && credentials.clientSecret) {


### PR DESCRIPTION
In https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/167, `dnt` parameter was added to the SLAS helper but I missed the `refreshAccessToken` helper. This PR fixe it.