### PR TITLE
[Bug] Fix dnt flag

### DIFF
--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -47,7 +47,7 @@ const parameters = {
   refreshToken: 'refresh_token',
   usid: 'usid',
   hint: 'hint',
-  dnt: true,
+  dnt: false,
 };
 
 const url =
@@ -219,7 +219,7 @@ describe('Guest user flow', () => {
         grant_type: 'authorization_code_pkce',
         redirect_uri: 'redirect_uri',
         usid: '048adcfb-aa93-4978-be9e-09cb569fdcb9',
-        dnt: 'true',
+        dnt: 'false',
       },
     };
     const mockSlasClient = createMockSlasClient();
@@ -257,7 +257,7 @@ describe('Guest user flow', () => {
         grant_type: 'client_credentials',
         channel_id: 'site_id',
         usid: 'usid',
-        dnt: 'true',
+        dnt: 'false',
       },
     };
     expect(getAccessTokenMock).toBeCalledWith(expectedReqOptions);
@@ -301,7 +301,7 @@ describe('Registered B2C user flow', () => {
       organizationId: 'organization_id',
       redirect_uri: 'redirect_uri',
       usid: '048adcfb-aa93-4978-be9e-09cb569fdcb9',
-      dnt: 'true',
+      dnt: 'false',
     },
   };
 
@@ -340,7 +340,7 @@ describe('Registered B2C user flow', () => {
         channel_id: 'site_id',
         organizationId: 'organization_id',
         usid: '048adcfb-aa93-4978-be9e-09cb569fdcb9',
-        dnt: 'true',
+        dnt: 'false',
       },
     };
     // slasClient is copied and tries to make an actual API call
@@ -443,7 +443,7 @@ describe('Refresh Token', () => {
         channel_id: 'site_id',
         grant_type: 'refresh_token',
         refresh_token: 'refresh_token',
-        dnt: 'true',
+        dnt: 'false',
       },
     };
     const token = slasHelper.refreshAccessToken(
@@ -466,7 +466,7 @@ describe('Refresh Token', () => {
         client_id: 'client_id',
         channel_id: 'site_id',
         refresh_token: parameters.refreshToken,
-        dnt: 'true',
+        dnt: 'false',
       },
     };
     const token = slasHelper.refreshAccessToken(

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -202,7 +202,7 @@ export async function loginGuestUserPrivate(
       grant_type: 'client_credentials',
       channel_id: slasClient.clientConfig.parameters.siteId,
       ...(parameters.usid && {usid: parameters.usid}),
-      ...(parameters.dnt && {dnt: parameters.dnt.toString()}),
+      ...(parameters.dnt !== undefined && {dnt: parameters.dnt.toString()}),
     },
   };
 
@@ -247,7 +247,7 @@ export async function loginGuestUser(
     grant_type: 'authorization_code_pkce',
     redirect_uri: parameters.redirectURI,
     usid: authResponse.usid,
-    ...(parameters.dnt && {dnt: parameters.dnt.toString()}),
+    ...(parameters.dnt !== undefined && {dnt: parameters.dnt.toString()}),
   };
 
   return slasClient.getAccessToken({body: tokenBody});
@@ -339,7 +339,7 @@ export async function loginRegisteredUserB2C(
     organizationId: slasClient.clientConfig.parameters.organizationId,
     redirect_uri: parameters.redirectURI,
     usid: authResponse.usid,
-    ...(parameters.dnt && {dnt: parameters.dnt.toString()}),
+    ...(parameters.dnt !== undefined && {dnt: parameters.dnt.toString()}),
   };
   // using slas private client
   if (credentials.clientSecret) {
@@ -387,7 +387,7 @@ export function refreshAccessToken(
     refresh_token: parameters.refreshToken,
     client_id: slasClient.clientConfig.parameters.clientId,
     channel_id: slasClient.clientConfig.parameters.siteId,
-    ...(parameters.dnt && {dnt: parameters.dnt.toString()}),
+    ...(parameters.dnt !== undefined && {dnt: parameters.dnt.toString()}),
   };
 
   if (credentials && credentials.clientSecret) {


### PR DESCRIPTION
There was a bug when the `dnt` flag is set to `false`, it will be omitted. This isn't what we want. This PR is to fix this issue.

## before

```js
...(parameters.dnt && {dnt: parameters.dnt.toString()}),
```

## after
```js
...(parameters.dnt !== undefined && {dnt: parameters.dnt.toString()}),
```

