### PR TITLE
Update response types to include `Object` for backward compatibility

### DIFF
--- a/templates/operations.ts.hbs
+++ b/templates/operations.ts.hbs
@@ -40,7 +40,7 @@
         body: {{{getPayloadTypeFromRequest request}}}
         {{/if}}
       }>
-    ): Promise<{{getReturnTypeFromOperation this}}>;
+    ): Promise<{{getReturnTypeFromOperation this}} | Object>;
 
     /**
     * {{{formatForTsDoc description}}}
@@ -80,7 +80,7 @@
         {{/if}}
       }>,
       rawResponse?: T
-    ): Promise<T extends true ? Response : {{getReturnTypeFromOperation this}}>;
+    ): Promise<T extends true ? Response : {{getReturnTypeFromOperation this}} | Object>;
 
     /**
     * {{{formatForTsDoc description}}}
@@ -121,7 +121,7 @@
         {{/if}}
       }>,
       rawResponse?: boolean
-    ): Promise<Response | {{getReturnTypeFromOperation this}}> {
+    ): Promise<Response | {{getReturnTypeFromOperation this}} | Object> {
       const optionParams = options?.parameters || ({} as Partial<NonNullable<NonNullable<typeof options>["parameters"]>>);
       const configParams = this.clientConfig.parameters;
 
@@ -204,7 +204,7 @@
         return response as Response;
       }
       {{else}}
-      return response as Response | {{getReturnTypeFromOperation this}};
+      return response as Response | {{getReturnTypeFromOperation this}} | Object;
       {{/if}}
     }
   {{/each}}


### PR DESCRIPTION
Due to breaking changes here: https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/182

We'll have to update our response types to include type `Object`. See https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/182#discussion_r1944896099 for more details