### PR TITLE
W-18089100 Allow custom params in helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v3.3.0
+- Allow custom params for 'loginGuestUser', 'authorizeIDP' and custom body/params for 'loginRegisteredUserB2C' functions [#186](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/186)
+
 ## v3.2.0
 
 ### Enhancements
@@ -7,7 +10,7 @@
 - Add SLAS passwordless login helpers [#173](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/173)
 - Add SLAS social login helper [#172](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/172)
 - Support Node 22 [#178](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/178)
-
+- 
 ### API Changes
 - The `expand` query parameter for `Shopper Products` calls now includes a new argument, `page_meta_tags`
 - The `expand` query parameter for `Shopper Search` calls now includes a new argument, `page_meta_tags`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## v3.3.0
-- Allow custom params for 'loginGuestUser', 'authorizeIDP' and custom body/params for 'loginRegisteredUserB2C' functions [#186](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/186)
+- Allow custom params for 'loginGuestUser', 'authorizeIDP' and custom body for 'loginRegisteredUserB2C' functions [#186](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/186)
 
 ## v3.2.0
 

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     },
     {
       "path": "commerce-sdk-isomorphic-with-deps.tgz",
-      "maxSize": "560 kB"
+      "maxSize": "561 kB"
     }
   ],
   "proxy": "https://SHORTCODE.api.commercecloud.salesforce.com"

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     },
     {
       "path": "commerce-sdk-isomorphic-with-deps.tgz",
-      "maxSize": "561 kB"
+      "maxSize": "560 kB"
     }
   ],
   "proxy": "https://SHORTCODE.api.commercecloud.salesforce.com"

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -770,6 +770,50 @@ describe('authorizePasswordless is working', () => {
       'Required argument channel_id is not provided through clientConfig.parameters.siteId'
     );
   });
+
+  test('Throw when required mode missing', async () => {
+    const mockSlasClient = createMockSlasClient();
+    const parametersAuthorizePasswordless = {
+      callbackURI: 'www.something.com/callback',
+      usid: 'a_usid',
+      userid: 'a_userid',
+      locale: 'a_locale',
+    };
+    await expect(
+      slasHelper.authorizePasswordless(
+        mockSlasClient,
+        credentialsPrivate,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore intentionally missing mode
+        parametersAuthorizePasswordless
+      )
+    ).rejects.toThrow(
+      'Required argument mode is not provided through parameters'
+    );
+  });
+
+  test('Throw when clientSecret is missing', async () => {
+    const mockSlasClient = createMockSlasClient();
+    const parametersAuthorizePasswordless = {
+      callbackURI: 'www.something.com/callback',
+      usid: 'a_usid',
+      userid: 'a_userid',
+      locale: 'a_locale',
+      mode: 'callback',
+    };
+    await expect(
+      slasHelper.authorizePasswordless(
+        mockSlasClient,
+        {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore intentionally missing mode
+          username: 'Jeff',
+          password: 'password',
+        },
+        parametersAuthorizePasswordless
+      )
+    ).rejects.toThrow('Required argument client secret is not provided');
+  });
 });
 
 describe('getPasswordLessAccessToken is working', () => {

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -267,12 +267,14 @@ describe('Authorize IDP User', () => {
     mockSlasClient.clientConfig.baseUri =
       'https://{shortCode}.api.commercecloud.salesforce.com/shopper/auth/{version}';
 
-    const authResponse = await slasHelper.authorizeIDP(
-      mockSlasClient,
-      parameters
-    );
+    const authResponse = await slasHelper.authorizeIDP(mockSlasClient, {
+      hint: parameters.hint,
+      redirectURI: parameters.redirectURI,
+      usid: parameters.usid,
+      c_param: 'test',
+    });
     const expectedAuthURL =
-      'https://short_code.api.commercecloud.salesforce.com/shopper/auth/v1/organizations/organization_id/oauth2/authorize?client_id=client_id&channel_id=site_id&hint=hint&redirect_uri=redirect_uri&response_type=code&usid=usid';
+      'https://short_code.api.commercecloud.salesforce.com/shopper/auth/v1/organizations/organization_id/oauth2/authorize?c_param=test&client_id=client_id&channel_id=site_id&hint=hint&redirect_uri=redirect_uri&response_type=code&usid=usid';
     expect(authResponse.url.replace(/[&?]code_challenge=[^&]*/, '')).toBe(
       expectedAuthURL
     );

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -578,9 +578,7 @@ describe('Registered B2C user flow', () => {
       },
       {
         body: {
-          redirect_uri: 'redirect_uri',
           c_body: 'test',
-          channel_id: 'site_id',
         },
       }
     );

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -551,9 +551,7 @@ describe('Registered B2C user flow', () => {
     expect(getAccessTokenMock).toBeCalledWith(expectedTokenBody);
   });
 
-  test('can pass custom body field, and throw warning for invalid params', async () => {
-    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-
+  test('can pass custom body field', async () => {
     // slasClient is copied and tries to make an actual API call
     const mockSlasClient = createMockSlasClient();
     const {shortCode, organizationId} = mockSlasClient.clientConfig.parameters;
@@ -572,9 +570,6 @@ describe('Registered B2C user flow', () => {
       {
         redirectURI: 'redirect_uri',
         dnt: false,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore intentionally passing invalid param
-        invalid_param: 'invalid param',
       },
       {
         body: {
@@ -582,14 +577,7 @@ describe('Registered B2C user flow', () => {
         },
       }
     );
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'Invalid Parameter for authenticateCustomer: invalid_param'
-      )
-    );
     expect(getAccessTokenMock).toBeCalledWith(expectedTokenBody);
-    // Restore the original console.warn
-    consoleWarnSpy.mockRestore();
   });
 
   test('uses code challenge and authorization header to generate auth code with slas private client', async () => {

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -278,7 +278,8 @@ describe('Authorize IDP User', () => {
 
 describe('IDP Login flow', () => {
   const loginParams = {
-    ...parameters,
+    redirectURI: 'redirect_uri',
+    dnt: false,
     usid: '048adcfb-aa93-4978-be9e-09cb569fdcb9',
     code: 'J2lHm0cgXmnXpwDhjhLoyLJBoUAlBfxDY-AhjqGMC-o',
   };
@@ -749,6 +750,13 @@ describe('Refresh Token', () => {
         refresh_token: parameters.refreshToken,
         dnt: 'false',
       },
+      parameters: {
+        accessToken: 'access_token',
+        hint: 'hint',
+        redirectURI: 'redirect_uri',
+        refreshToken: 'refresh_token',
+        usid: 'usid',
+      },
     };
     const token = slasHelper.refreshAccessToken(
       createMockSlasClient(),
@@ -775,7 +783,10 @@ describe('Logout', () => {
   };
 
   test('logs out the customer', () => {
-    const token = slasHelper.logout(createMockSlasClient(), parameters);
+    const token = slasHelper.logout(createMockSlasClient(), {
+      accessToken: 'access_token',
+      refreshToken: 'refresh_token',
+    });
     expect(logoutCustomerMock).toBeCalledWith(expectedOptions);
     expect(token).toStrictEqual(expectedTokenResponse);
   });

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -109,7 +109,7 @@ export const generateCodeChallenge = async (
  * @param parameters.redirectURI - the location the client will be returned to after successful login with 3rd party IDP. Must be registered in SLAS.
  * @param parameters.hint? - optional string to hint at a particular IDP. Guest sessions are created by setting this to 'guest'
  * @param parameters.usid? - optional saved SLAS user id to link the new session to a previous session
- * @param privateClient - flag to indicate if the client is private or not. Defaults to false.
+ * @param privateClient? - flag to indicate if the client is private or not. Defaults to false.
  * @param options - an object containing the options for this method.
  * @param options.headers? - optional header to pass in the 'authorizeCustomer` endpoint.
  * @returns login url, user id and authorization code if available

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -452,7 +452,7 @@ export async function loginRegisteredUserB2C(
     dnt?: boolean;
   } & CustomQueryParameters,
   options?: {
-    body?: CustomRequestBody & LoginRequest;
+    body?: CustomRequestBody;
   }
 ): Promise<TokenResponse> {
   const codeVerifier = createCodeVerifier();

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -368,7 +368,7 @@ export async function loginGuestUserPrivate(
 /**
  * A single function to execute the ShopperLogin Public Client Guest Login with proof key for code exchange flow as described in the [API documentation](https://developer.salesforce.com/docs/commerce/commerce-api/references?meta=shopper-login:Summary).
  * @param slasClient a configured instance of the ShopperLogin SDK client.
- * @param parameters - parameters to pass in the API calls. Custom parameters can be passed on by adding a property on the `parameters` object starting with `c_`, and they will be passed to `authorizeCustomer` call.
+ * @param parameters - parameters to pass in the API calls. Custom parameters can be passed on by adding a property on the `parameters` object starting with `c_`, and they will be passed on the `authorizeCustomer` call.
  * @param parameters.redirectURI - Per OAuth standard, a valid app route. Must be listed in your SLAS configuration. On server, this will not be actually called. On browser, this will be called, but ignored.
  * @param parameters.usid? - Unique Shopper Identifier to enable personalization.
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -207,9 +207,10 @@ export async function authorizeIDP(
     redirectURI: string;
     hint: string;
     usid?: string;
-  },
+  } & CustomQueryParameters,
   privateClient = false
 ): Promise<{url: string; codeVerifier: string}> {
+  const {hint, redirectURI, usid, ...restOfParams} = parameters;
   const codeVerifier = createCodeVerifier();
   interface ClientOptions {
     codeChallenge?: string;
@@ -227,15 +228,17 @@ export async function authorizeIDP(
     version: slasClient.clientConfig.parameters.version || 'v1',
   };
   const queryParams: ShopperLoginQueryParameters = {
+    // put it at the top to avoid overriding the rest of params
+    ...restOfParams,
     client_id: slasClient.clientConfig.parameters.clientId,
     channel_id: slasClient.clientConfig.parameters.siteId,
     ...(clientOptions.codeChallenge && {
       code_challenge: clientOptions.codeChallenge,
     }),
-    hint: parameters.hint,
-    redirect_uri: parameters.redirectURI,
+    hint,
+    redirect_uri: redirectURI,
     response_type: 'code',
-    ...(parameters.usid && {usid: parameters.usid}),
+    ...(usid && {usid}),
   };
 
   const url = new TemplateURL(apiPath, slasClient.clientConfig.baseUri, {

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -425,7 +425,7 @@ export async function loginGuestUser(
  * @param credentials.username - the id of the user to login with.
  * @param credentials.password - the password of the user to login with.
  * @param credentials.clientSecret? - secret associated with client ID
- * @param parameters - parameters to pass in the API calls. Custom parameters can be passed on by adding a property on the `parameters` object starting with `c_`, and they will be passed to `authenticateCustomer` call.
+ * @param parameters - parameters to pass in the API calls.
  * @param parameters.redirectURI - Per OAuth standard, a valid app route. Must be listed in your SLAS configuration. On server, this will not be actually called. On browser, this will be called, but ignored.
  * @param parameters.usid? - Unique Shopper Identifier to enable personalization.
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
@@ -449,7 +449,7 @@ export async function loginRegisteredUserB2C(
     redirectURI: string;
     usid?: string;
     dnt?: boolean;
-  } & CustomQueryParameters,
+  },
   options?: {
     body?: CustomRequestBody;
   }
@@ -472,14 +472,12 @@ export async function loginRegisteredUserB2C(
   const authorization = `Basic ${stringToBase64(
     `${credentials.username}:${credentials.password}`
   )}`;
-  const {dnt, usid, redirectURI, ...restOfParams} = parameters;
+  const {dnt, usid, redirectURI} = parameters;
   const opts = {
     headers: {
       Authorization: authorization,
     },
     parameters: {
-      // putting this at the top to avoid any overriding on the required query param below
-      ...restOfParams,
       organizationId: slasClient.clientConfig.parameters.organizationId,
     },
     body: {

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -10,7 +10,6 @@ import seedrandom, {PRNG} from 'seedrandom';
 import {isBrowser} from './environment';
 
 import {
-  LoginRequest,
   ShopperLogin,
   ShopperLoginPathParameters,
   ShopperLoginQueryParameters,

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -419,7 +419,6 @@ export async function loginGuestUser(
 
   return slasClient.getAccessToken({body: tokenBody, headers});
 }
-type BodyRequest = LoginRequest & {[key in `c_${string}`]: any};
 
 /**
  * A single function to execute the ShopperLogin Public Client Registered User B2C Login with proof key for code exchange flow as described in the [API documentation](https://developer.salesforce.com/docs/commerce/commerce-api/references?meta=shopper-login:Summary).

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -439,7 +439,7 @@ export async function loginGuestUser(
       ...(usid && {usid}),
     },
     false,
-    {headers: options?.headers}
+    options?.headers && {headers: options.headers}
   );
   const tokenBody: TokenRequest = {
     client_id: slasClient.clientConfig.parameters.clientId,
@@ -454,7 +454,7 @@ export async function loginGuestUser(
 
   return slasClient.getAccessToken({
     body: tokenBody,
-    headers: options?.headers,
+    ...(options?.headers && {headers: options.headers}),
     // only add custom parameters if there are any
     ...(Object.keys(restOfParams).length > 0 && {parameters: restOfParams}),
   });
@@ -529,12 +529,12 @@ export async function loginRegisteredUserB2C(
       organizationId: slasClient.clientConfig.parameters.organizationId,
     },
     body: {
+      ...(options?.body || {}),
       redirect_uri: redirectURI,
       client_id: slasClient.clientConfig.parameters.clientId,
       code_challenge: codeChallenge,
       channel_id: slasClient.clientConfig.parameters.siteId,
       ...(usid && {usid}),
-      ...(options?.body || {}),
     },
   };
 
@@ -568,18 +568,19 @@ export async function loginRegisteredUserB2C(
     const optionsToken = {
       headers: {
         // do not allow overriding of the Authorization header
-        ...options?.headers,
+        ...(options?.headers || {}),
         Authorization: authHeaderIdSecret,
       },
       body: tokenBody,
+      ...(Object.keys(restOfParams).length > 0 && {parameters: restOfParams}),
     };
     return slasClient.getAccessToken(optionsToken);
   }
   // default is to use slas public client
   return slasClient.getAccessToken({
     body: tokenBody,
-    headers: options?.headers,
-    ...(Object.keys(parameters) && {parameters: restOfParams}),
+    ...(options?.headers && {headers: options.headers}),
+    ...(Object.keys(restOfParams).length > 0 && {parameters: restOfParams}),
   });
 }
 
@@ -785,7 +786,7 @@ export function refreshAccessToken(
       `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
     )}`;
     const opts = {
-      ...(Object.keys(parameters) && {parameters: restOfParams}),
+      ...(Object.keys(restOfParams) && {parameters: restOfParams}),
       headers: {
         // we don't want any overriding for the Authorization header
         ...options?.headers,
@@ -798,8 +799,8 @@ export function refreshAccessToken(
 
   return slasClient.getAccessToken({
     body,
-    headers: options?.headers,
-    ...(Object.keys(parameters) && {parameters: restOfParams}),
+    ...(options?.headers && {headers: options.headers}),
+    ...(Object.keys(restOfParams) && {parameters: restOfParams}),
   });
 }
 

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -110,7 +110,7 @@ export const generateCodeChallenge = async (
  * @param parameters.hint? - optional string to hint at a particular IDP. Guest sessions are created by setting this to 'guest'
  * @param parameters.usid? - optional saved SLAS user id to link the new session to a previous session
  * @param privateClient? - flag to indicate if the client is private or not. Defaults to false.
- * @param options - an object containing the options for this method.
+ * @param options - an object containing the options for this function.
  * @param options.headers? - optional header to pass in the 'authorizeCustomer` endpoint.
  * @returns login url, user id and authorization code if available
  */
@@ -261,7 +261,7 @@ export async function authorizeIDP(
  * @param parameters.redirectURI - Per OAuth standard, a valid app route. Must be listed in your SLAS configuration. On server, this will not be actually called. On browser, this will be called, but ignored.
  * @param parameters.usid? - Unique Shopper Identifier to enable personalization.
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
- * @param options - an object containing the options for this method
+ * @param options - an object containing the options for this function
  * @param options?.headers - optional headers to pass in the 'getAccessToken'
  * @returns TokenResponse
  */
@@ -336,7 +336,7 @@ export async function loginIDPUser(
  * @param parameters - parameters to pass in the API calls.
  * @param parameters.usid? - Unique Shopper Identifier to enable personalization.
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
- * @param options - an object containing the options for this method.
+ * @param options - an object containing the options for this function.
  * @param option.headers? - optional headers to pass in the 'getAccessToken` endpoint.
  * @returns TokenResponse
  */
@@ -390,7 +390,7 @@ export async function loginGuestUserPrivate(
  * @param parameters.redirectURI - Per OAuth standard, a valid app route. Must be listed in your SLAS configuration. On server, this will not be actually called. On browser, this will be called, but ignored.
  * @param parameters.usid? - Unique Shopper Identifier to enable personalization.
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
- * @param options - an object containing the options for this method.
+ * @param options - an object containing the options for this function.
  * @param option.headers? - optional headers to pass in the 'getAccessToken` endpoint.
  * @returns TokenResponse
  */
@@ -454,7 +454,7 @@ export async function loginGuestUser(
  * @param parameters.redirectURI - Per OAuth standard, a valid app route. Must be listed in your SLAS configuration. On server, this will not be actually called. On browser, this will be called, but ignored.
  * @param parameters.usid? - Unique Shopper Identifier to enable personalization.
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
- * @param options - an object containing the options for this method.
+ * @param options - an object containing the options for this function.
  * @param options.headers - optional headers to pass in the 'getAccessToken' and 'authenticateCustomer' endpoints.
  * @param options.body - optional body parameters to pass in the 'authenticateCustomer' endpoint.
  * @returns TokenResponse
@@ -573,7 +573,7 @@ export async function loginRegisteredUserB2C(
  * @param parameters.userid - User Id for login
  * @param parameters.locale - The locale of the template. Not needed for the callback mode
  * @param parameters.mode - Medium of sending login token
- * @param options - an object containing the options for this method.
+ * @param options - an object containing the options for this function.
  * @param options?.headers - optional headers to pass in the 'authorizePasswordlessCustomer' endpoint
  * @returns Promise of Response
  */
@@ -655,7 +655,7 @@ export async function authorizePasswordless(
  * @param parameters.callbackURI? - URI to send the passwordless login token to. Must be listed in your SLAS configuration. Required when mode is callback
  * @param parameters.pwdlessLoginToken - Passwordless login token
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
- * @param options - an object containing the options for this method.
+ * @param options - an object containing the options for this function.
  * @param options?.headers - optional headers to pass in the 'getPasswordLessAccessToken' endpoint
  * @returns Promise of Response or Object
  */
@@ -724,7 +724,7 @@ export async function getPasswordLessAccessToken(
  * @param parameters.refreshToken - a valid refresh token to exchange for a new access token (and refresh token).
  * @param credentials - the clientSecret (if applicable) to login with.
  * @param credentials.clientSecret - secret associated with client ID
- * @param options - an object containing the options for this method.
+ * @param options - an object containing the options for this function.
  * @param options?.headers - optional headers to pass in the 'getAccessToken' endpoint
  * @returns TokenResponse
  */
@@ -777,7 +777,7 @@ export function refreshAccessToken(
  * @param parameters - parameters to pass in the API calls.
  * @param parameters.accessToken - a valid access token to exchange for a new access token (and refresh token).
  * @param parameters.refreshToken - a valid refresh token to exchange for a new access token (and refresh token).
- * @param options - an object containing the options for this method.
+ * @param options - an object containing the options for this function.
  * @param options?.headers - optional headers to pass in the 'logoutCustomer' endpoint
  * @returns TokenResponse
  */

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -104,7 +104,7 @@ export const generateCodeChallenge = async (
  * Wrapper for the authorization endpoint. For federated login (3rd party IDP non-guest), the caller should redirect the user to the url in the url field of the returned object. The url will be the login page for the 3rd party IDP and the user will be sent to the redirectURI on success. Guest sessions return the code and usid directly with no need to redirect.
  * @param slasClient a configured instance of the ShopperLogin SDK client
  * @param codeVerifier - random string created by client app to use as a secret in the request
- * @param parameters - Request parameters used by the `authorizeCustomer` endpoint.
+ * @param parameters - Request parameters used by the `authorizeCustomer` endpoint. Custom parameters can be passed on by adding a property on the `parameters` object starting with `c_`
  * @param parameters.redirectURI - the location the client will be returned to after successful login with 3rd party IDP. Must be registered in SLAS.
  * @param parameters.hint? - optional string to hint at a particular IDP. Guest sessions are created by setting this to 'guest'
  * @param parameters.usid? - optional saved SLAS user id to link the new session to a previous session
@@ -187,7 +187,7 @@ export async function authorize(
 /**
  * Function to return the URL of the authorization endpoint. The url will redirect to the login page for the 3rd party IDP and the user will be sent to the redirectURI on success. Guest sessions return the code and usid directly with no need to redirect.
  * @param slasClient a configured instance of the ShopperLogin SDK client
- * @param parameters - Request parameters used by the `authorizeCustomer` endpoint.
+ * @param parameters - Request parameters used by the `authorizeCustomer` endpoint. Custom parameters can be passed on by adding a property on the `parameters` object starting with `c_`
  * @param parameters.redirectURI - the location the client will be returned to after successful login with 3rd party IDP. Must be registered in SLAS.
  * @param parameters.hint - string to hint at a particular IDP. Required for 3rd party IDP login.
  * @param parameters.usid? - optional saved SLAS user id to link the new session to a previous session
@@ -368,7 +368,7 @@ export async function loginGuestUserPrivate(
 /**
  * A single function to execute the ShopperLogin Public Client Guest Login with proof key for code exchange flow as described in the [API documentation](https://developer.salesforce.com/docs/commerce/commerce-api/references?meta=shopper-login:Summary).
  * @param slasClient a configured instance of the ShopperLogin SDK client.
- * @param parameters - parameters to pass in the API calls.
+ * @param parameters - parameters to pass in the API calls. Custom parameters can be passed on by adding a property on the `parameters` object starting with `c_`, and they will be passed to `authorizeCustomer` call.
  * @param parameters.redirectURI - Per OAuth standard, a valid app route. Must be listed in your SLAS configuration. On server, this will not be actually called. On browser, this will be called, but ignored.
  * @param parameters.usid? - Unique Shopper Identifier to enable personalization.
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
@@ -425,7 +425,7 @@ export async function loginGuestUser(
  * @param credentials.username - the id of the user to login with.
  * @param credentials.password - the password of the user to login with.
  * @param credentials.clientSecret? - secret associated with client ID
- * @param parameters - parameters to pass in the API calls.
+ * @param parameters - parameters to pass in the API calls. Custom parameters can be passed on by adding a property on the `parameters` object starting with `c_`, and they will be passed to `authenticateCustomer` call.
  * @param parameters.redirectURI - Per OAuth standard, a valid app route. Must be listed in your SLAS configuration. On server, this will not be actually called. On browser, this will be called, but ignored.
  * @param parameters.usid? - Unique Shopper Identifier to enable personalization.
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -111,7 +111,7 @@ export const generateCodeChallenge = async (
  * @param parameters.usid? - optional saved SLAS user id to link the new session to a previous session
  * @param privateClient? - flag to indicate if the client is private or not. Defaults to false.
  * @param options - an object containing the options for this function.
- * @param options.headers? - optional header to pass in the 'authorizeCustomer` endpoint.
+ * @param options.headers? - optional header to pass in the  ShopperLogin 'authorizeCustomer` method.
  * @returns login url, user id and authorization code if available
  */
 export async function authorize(
@@ -262,7 +262,7 @@ export async function authorizeIDP(
  * @param parameters.usid? - Unique Shopper Identifier to enable personalization.
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
  * @param options - an object containing the options for this function
- * @param options?.headers - optional headers to pass in the 'getAccessToken'
+ * @param options?.headers - optional headers to pass in the ShopperLogin 'getAccessToken' method
  * @returns TokenResponse
  */
 export async function loginIDPUser(
@@ -337,7 +337,7 @@ export async function loginIDPUser(
  * @param parameters.usid? - Unique Shopper Identifier to enable personalization.
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
  * @param options - an object containing the options for this function.
- * @param option.headers? - optional headers to pass in the 'getAccessToken` endpoint.
+ * @param option.headers? - optional headers to pass in the ShopperLogin 'getAccessToken' method
  * @returns TokenResponse
  */
 export async function loginGuestUserPrivate(
@@ -391,7 +391,7 @@ export async function loginGuestUserPrivate(
  * @param parameters.usid? - Unique Shopper Identifier to enable personalization.
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
  * @param options - an object containing the options for this function.
- * @param option.headers? - optional headers to pass in the 'getAccessToken` endpoint.
+ * @param option.headers? - optional headers to pass in the ShopperLogin 'getAccessToken' method
  * @returns TokenResponse
  */
 export async function loginGuestUser(
@@ -455,8 +455,8 @@ export async function loginGuestUser(
  * @param parameters.usid? - Unique Shopper Identifier to enable personalization.
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
  * @param options - an object containing the options for this function.
- * @param options.headers - optional headers to pass in the 'getAccessToken' and 'authenticateCustomer' endpoints.
- * @param options.body - optional body parameters to pass in the 'authenticateCustomer' endpoint.
+ * @param options.headers - optional headers to pass in the ShopperLogin 'getAccessToken' and 'authenticateCustomer' methods.
+ * @param options.body - optional body parameters to pass in the ShopperLogin 'authenticateCustomer' method.
  * @returns TokenResponse
  */
 export async function loginRegisteredUserB2C(
@@ -574,7 +574,7 @@ export async function loginRegisteredUserB2C(
  * @param parameters.locale - The locale of the template. Not needed for the callback mode
  * @param parameters.mode - Medium of sending login token
  * @param options - an object containing the options for this function.
- * @param options?.headers - optional headers to pass in the 'authorizePasswordlessCustomer' endpoint
+ * @param options?.headers - optional headers to pass in the ShopperLogin 'authorizePasswordlessCustomer' method
  * @returns Promise of Response
  */
 export async function authorizePasswordless(
@@ -656,7 +656,7 @@ export async function authorizePasswordless(
  * @param parameters.pwdlessLoginToken - Passwordless login token
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
  * @param options - an object containing the options for this function.
- * @param options?.headers - optional headers to pass in the 'getPasswordLessAccessToken' endpoint
+ * @param options?.headers - optional headers to pass in the ShopperLogin 'getPasswordLessAccessToken' method
  * @returns Promise of Response or Object
  */
 export async function getPasswordLessAccessToken(
@@ -725,7 +725,7 @@ export async function getPasswordLessAccessToken(
  * @param credentials - the clientSecret (if applicable) to login with.
  * @param credentials.clientSecret - secret associated with client ID
  * @param options - an object containing the options for this function.
- * @param options?.headers - optional headers to pass in the 'getAccessToken' endpoint
+ * @param options?.headers - optional headers to pass in the ShopperLogin 'getAccessToken' method
  * @returns TokenResponse
  */
 export function refreshAccessToken(
@@ -778,7 +778,7 @@ export function refreshAccessToken(
  * @param parameters.accessToken - a valid access token to exchange for a new access token (and refresh token).
  * @param parameters.refreshToken - a valid refresh token to exchange for a new access token (and refresh token).
  * @param options - an object containing the options for this function.
- * @param options?.headers - optional headers to pass in the 'logoutCustomer' endpoint
+ * @param options?.headers - optional headers to pass in the  ShopperLogin 'logoutCustomer' method
  * @returns TokenResponse
  */
 export function logout(

--- a/src/static/helpers/types.ts
+++ b/src/static/helpers/types.ts
@@ -79,5 +79,5 @@ export type CustomRequestBody = {
     | boolean
     | string[]
     | number[]
-    | {[key: string]: any};
+    | {[key: string]: unknown};
 };

--- a/src/static/helpers/types.ts
+++ b/src/static/helpers/types.ts
@@ -73,5 +73,11 @@ export type CustomQueryParameters = {
  * types for the value.
  */
 export type CustomRequestBody = {
-  [key in `c_${string}`]: string | number | boolean | string[] | number[];
+  [key in `c_${string}`]:
+    | string
+    | number
+    | boolean
+    | string[]
+    | number[]
+    | {[key: string]: any};
 };

--- a/src/static/helpers/types.ts
+++ b/src/static/helpers/types.ts
@@ -59,3 +59,19 @@ export interface QueryParameters {
  * Generic interface for all parameter types.
  */
 export type UrlParameters = PathParameters | QueryParameters;
+
+/**
+ * Custom query parameter type with any string prefixed with `c_` as the key and the allowed
+ * types for query parameters for the value.
+ */
+export type CustomQueryParameters = {
+  [key in `c_${string}`]: string | number | boolean | string[] | number[];
+};
+
+/**
+ * Custom body request type with any string prefixed with `c_` as the key and the allowed
+ * types for the value.
+ */
+export type CustomRequestBody = {
+  [key in `c_${string}`]: string | number | boolean | string[] | number[];
+};


### PR DESCRIPTION
This PR allows custom parameters to be passed into `/authorize` endpoint via the `loginGuestUser` and `authorizeIDP` helpers  and `/login` via `loginRegisteredUsers` helper. 

- Customer headers are not allowed and will be ignored via SLAS
Some Note on the authorize endpoint
- The /authorize endpoint does not call SCAPI / OCAPI customers/auth where the hooks take place.
- The /authorize endpoint is used for "Social" or 3rd party logins (okta, Auth0, etc.). SLAS will call out to the given Identity Provider (IDP) to have the user log in.
- For /authorize endpoint the "c_" parameters are passed to the 3rd party IDP and no ECOM hooks are involved.
- /login will have authentication hooks. See [here](https://developer.salesforce.com/docs/commerce/commerce-api/guide/hook-method-details.html)

How to test drive PR
- Check out code
- yarn install
- yarn test and confirm all the tests are all passed