### PR TITLE
Feat: Refactor Isomorphic SDK (@W-18709921@)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@
 - Enum types have been added for certain operations and types
 - Certain operations have had types updated for query parameters
 - SLAS helpers have been refactored to accept a single `options` object argument, where the properties are the old arguments
-- 
+- Path parameter special characters are encoded by default
+- Allow custom properties on request bodies to be passed
+- Remove API version from client config
+  - Use `ShopperBasketsV2` API class to use V2 of Shopper Baskets
 
 ## v3.3.0
 - Allow custom params for 'loginGuestUser', 'authorizeIDP' and custom body for 'loginRegisteredUserB2C' functions [#186](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/186)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 4.0.0-dev
+
+### Enchancements
+
+- Enum types have been added for certain operations and types
+- Certain operations have had types updated for query parameters
+- SLAS helpers have been refactored to accept a single `options` object argument, where the properties are the old arguments
+- 
+
 ## v3.3.0
 - Allow custom params for 'loginGuestUser', 'authorizeIDP' and custom body for 'loginRegisteredUserB2C' functions [#186](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/186)
 - Add helper to encode special SCAPI characters [#189](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/189)

--- a/README.md
+++ b/README.md
@@ -239,9 +239,9 @@ const scapiSpecialEncodedId = helpers.encodeSCAPISpecialCharacters(categoryId);
 // <base-url>/product/shopper-products/v1/organizations/{organizationId}/categories/{id}
 const categoryResult = await shopperProducts.getCategory({
   parameters: {
-    // Path parameters are NOT encoded by the SDK, so we have to single encode special characters
-    // and the SCAPI special characters will end up double encoded
-    id: encodeURIComponent(scapiSpecialEncodedId),
+    // No need to use `encodeURIComponent` as query parameters are single encoded by the SDK
+    // So the SCAPI special characters will end up double encoded as well
+    id: scapiSpecialEncodedId,
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "renderTemplates": "PACKAGE_VERSION=$(node -p \"require('./package.json').version\") ts-node --compiler-options '{\"module\": \"commonjs\", \"target\": \"ES6\" }' ./scripts/generate-oas.ts",
     "start": "HTTPS=true react-scripts start",
     "pretest": "yarn run lint && yarn run lint:style && depcheck && yarn run check:size",
-    "test": "yarn run check:types && yarn run test:unit",
+    "test": "yarn run check:types && yarn run test:unit && CI=true yarn run test:react",
     "test:react": "react-scripts test --env=jest-environment-jsdom-sixteen src/environment",
     "test:unit": "jest --coverage --testPathIgnorePatterns node_modules src/environment --silent",
     "updateApis": "ts-node --compiler-options '{\"module\": \"commonjs\", \"target\": \"ES6\" }' ./scripts/updateApis.ts && yarn diffApis"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "renderTemplates": "PACKAGE_VERSION=$(node -p \"require('./package.json').version\") ts-node --compiler-options '{\"module\": \"commonjs\", \"target\": \"ES6\" }' ./scripts/generate-oas.ts",
     "start": "HTTPS=true react-scripts start",
     "pretest": "yarn run lint && yarn run lint:style && depcheck && yarn run check:size",
-    "test": "yarn run check:types && yarn run test:unit && CI=true yarn run test:react",
+    "test": "yarn run check:types && yarn run test:unit",
     "test:react": "react-scripts test --env=jest-environment-jsdom-sixteen src/environment",
     "test:unit": "jest --coverage --testPathIgnorePatterns node_modules src/environment --silent",
     "updateApis": "ts-node --compiler-options '{\"module\": \"commonjs\", \"target\": \"ES6\" }' ./scripts/updateApis.ts && yarn diffApis"

--- a/scripts/generate-oas.test.ts
+++ b/scripts/generate-oas.test.ts
@@ -28,14 +28,13 @@ jest.mock('@commerce-apps/raml-toolkit', () => ({
 
 describe('generate-oas', () => {
   const mockApiDirectory = '/mock/api/directory';
-  let handlebarsSpy: jest.SpyInstance;
 
   beforeEach(() => {
     // Reset all mocks before each test
     jest.clearAllMocks();
 
     // Set up Handlebars spy
-    handlebarsSpy = jest.spyOn(Handlebars, 'compile');
+    jest.spyOn(Handlebars, 'compile');
 
     // Mock fs-extra methods
     (fs.existsSync as jest.Mock).mockReturnValue(true);

--- a/src/environment/App/App.jsx
+++ b/src/environment/App/App.jsx
@@ -73,8 +73,11 @@ class App extends Component {
   }
 
   async getToken() {
-    const authResponse = await slasHelper.loginGuestUser(slasClient, {
-      redirectURI: new URL('/callback', window.location).href,
+    const authResponse = await slasHelper.loginGuestUser({
+      slasClient,
+      parameters: {
+        redirectURI: new URL('/callback', window.location).href,
+      }
     });
     this.state.token = `Bearer ${authResponse.access_token}`;
   }

--- a/src/static/helpers/fetchHelper.ts
+++ b/src/static/helpers/fetchHelper.ts
@@ -25,7 +25,6 @@ import {ClientConfigInit} from '../clientConfig';
  * @param rawResponse? - Flag to return the raw response from the fetch call. True for raw response object, false for the data from the response
  * @returns Raw response or data from response based on rawResponse argument from fetch call
  */
-// eslint-disable-next-line import/prefer-default-export
 export const doFetch = async <Params extends BaseUriParameters>(
   url: string,
   options?: {

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -281,7 +281,7 @@ describe('Authorize IDP User', () => {
   test('returns authorization url for 3rd party idp login', async () => {
     const mockSlasClient = createMockSlasClient();
     mockSlasClient.clientConfig.baseUri =
-      'https://{shortCode}.api.commercecloud.salesforce.com/shopper/auth/{version}';
+      'https://{shortCode}.api.commercecloud.salesforce.com/shopper/auth/v1';
 
     const authResponse = await slasHelper.authorizeIDP({
       slasClient: mockSlasClient,

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -171,11 +171,11 @@ describe('Authorize user', () => {
       .query(true)
       .reply(303, {response_body: 'response_body'}, {location: url});
 
-    const authResponse = await slasHelper.authorize(
-      mockSlasClient,
+    const authResponse = await slasHelper.authorize({
+      slasClient: mockSlasClient,
       codeVerifier,
-      parameters
-    );
+      parameters,
+    });
     expect(authResponse).toStrictEqual(expectedAuthResponse);
   });
 
@@ -193,7 +193,11 @@ describe('Authorize user', () => {
       .reply(200);
 
     await expect(
-      slasHelper.authorize(mockSlasClient, codeVerifier, parameters)
+      slasHelper.authorize({
+        slasClient: mockSlasClient,
+        codeVerifier,
+        parameters,
+      })
     ).rejects.toThrow(ResponseError);
   });
 
@@ -229,14 +233,19 @@ describe('Authorize user', () => {
         return [303, {response_body: 'response_body'}, {location: url}];
       });
 
-    await slasHelper.authorize(mockSlasClient, codeVerifier, parameters, true);
+    await slasHelper.authorize({
+      slasClient: mockSlasClient,
+      codeVerifier,
+      parameters,
+      privateClient: true,
+    });
 
     // There should be no code_challenge for private client
     const expectedReqOptions = {
-      accessToken: "access_token",
+      accessToken: 'access_token',
       client_id: 'client_id',
       channel_id: 'site_id',
-      dnt: "false",
+      dnt: 'false',
       hint: 'hint',
       redirect_uri: 'redirect_uri',
       refreshToken: 'refresh_token',
@@ -257,9 +266,13 @@ test('throws error on 400 response', async () => {
     .reply(400, {response_body: 'response_body'}, {location: ''});
 
   await expect(
-    slasHelper.authorize(mockSlasClient, codeVerifier, {
-      redirectURI: parameters.redirectURI,
-      usid: parameters.usid,
+    slasHelper.authorize({
+      slasClient: mockSlasClient,
+      codeVerifier,
+      parameters: {
+        redirectURI: parameters.redirectURI,
+        usid: parameters.usid,
+      },
     })
   ).rejects.toThrow(ResponseError);
 });
@@ -270,11 +283,14 @@ describe('Authorize IDP User', () => {
     mockSlasClient.clientConfig.baseUri =
       'https://{shortCode}.api.commercecloud.salesforce.com/shopper/auth/{version}';
 
-    const authResponse = await slasHelper.authorizeIDP(mockSlasClient, {
-      hint: parameters.hint,
-      redirectURI: parameters.redirectURI,
-      usid: parameters.usid,
-      c_param: 'test',
+    const authResponse = await slasHelper.authorizeIDP({
+      slasClient: mockSlasClient,
+      parameters: {
+        hint: parameters.hint,
+        redirectURI: parameters.redirectURI,
+        usid: parameters.usid,
+        c_param: 'test',
+      },
     });
     const expectedAuthURL =
       'https://short_code.api.commercecloud.salesforce.com/shopper/auth/v1/organizations/organization_id/oauth2/authorize?c_param=test&client_id=client_id&channel_id=site_id&hint=hint&redirect_uri=redirect_uri&response_type=code&usid=usid';
@@ -302,11 +318,11 @@ describe('IDP Login flow', () => {
     .reply(303, {response_body: 'response_body'}, {location: url});
 
   test('retrieves usid and code and generates an access token for private client', async () => {
-    const accessToken = await slasHelper.loginIDPUser(
-      mockSlasClient,
-      {clientSecret: credentialsPrivate.clientSecret},
-      loginParams
-    );
+    const accessToken = await slasHelper.loginIDPUser({
+      slasClient: mockSlasClient,
+      credentials: {clientSecret: credentialsPrivate.clientSecret},
+      parameters: loginParams,
+    });
 
     const expectedReqOptions = {
       headers: {
@@ -330,11 +346,11 @@ describe('IDP Login flow', () => {
   });
 
   test('retrieves usid and code and generates an access token for public client', async () => {
-    const accessToken = await slasHelper.loginIDPUser(
-      mockSlasClient,
-      {codeVerifier: 'code_verifier'},
-      loginParams
-    );
+    const accessToken = await slasHelper.loginIDPUser({
+      slasClient: mockSlasClient,
+      credentials: {codeVerifier: 'code_verifier'},
+      parameters: loginParams,
+    });
 
     const expectedReqOptions = {
       body: {
@@ -376,9 +392,12 @@ describe('Guest user flow', () => {
       .query(true)
       .reply(303, {response_body: 'response_body'}, {location: url});
 
-    const accessToken = await slasHelper.loginGuestUser(mockSlasClient, {
-      redirectURI: parameters.redirectURI,
-      dnt: false,
+    const accessToken = await slasHelper.loginGuestUser({
+      slasClient: mockSlasClient,
+      parameters: {
+        redirectURI: parameters.redirectURI,
+        dnt: false,
+      },
     });
     expect(getAccessTokenMock).toBeCalledWith(expectedTokenBody);
     expect(accessToken).toBe(expectedTokenResponse);
@@ -408,17 +427,22 @@ describe('Guest user flow', () => {
       .query(true)
       .reply(303, {response_body: 'response_body'}, {location: url});
 
-    const accessToken = await slasHelper.loginGuestUser(mockSlasClient, {
-      redirectURI: parameters.redirectURI,
-      dnt: false,
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      hello: 'world',
+    const accessToken = await slasHelper.loginGuestUser({
+      slasClient: mockSlasClient,
+      parameters: {
+        redirectURI: parameters.redirectURI,
+        dnt: false,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        hello: 'world',
+      },
     });
 
     // Assert the warning was logged
     expect(consoleWarnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Found unknown parameter for authorizeCustomer: hello, adding as query parameter anyway')
+      expect.stringContaining(
+        'Found unknown parameter for authorizeCustomer: hello, adding as query parameter anyway'
+      )
     );
 
     expect(getAccessTokenMock).toBeCalledWith(expectedTokenBody);
@@ -449,10 +473,13 @@ describe('Guest user flow', () => {
       .query(query => query.c_color === 'red')
       .reply(303, {response_body: 'response_body'}, {location: url});
 
-    const accessToken = await slasHelper.loginGuestUser(mockSlasClient, {
-      redirectURI: parameters.redirectURI,
-      dnt: false,
-      c_color: 'red',
+    const accessToken = await slasHelper.loginGuestUser({
+      slasClient: mockSlasClient,
+      parameters: {
+        redirectURI: parameters.redirectURI,
+        dnt: false,
+        c_color: 'red',
+      },
     });
 
     // Verify getAccessToken was called with the right parameters,
@@ -464,11 +491,11 @@ describe('Guest user flow', () => {
   test('generates an access token using slas private client', async () => {
     const mockSlasClient = createMockSlasClient();
 
-    const accessToken = await slasHelper.loginGuestUserPrivate(
-      mockSlasClient,
+    const accessToken = await slasHelper.loginGuestUserPrivate({
+      slasClient: mockSlasClient,
       parameters,
-      credentialsPrivate
-    );
+      credentials: credentialsPrivate,
+    });
 
     const expectedReqOptions = {
       headers: {
@@ -500,13 +527,13 @@ describe('Guest user flow', () => {
     };
 
     await expect(
-      slasHelper.loginGuestUserPrivate(
+      slasHelper.loginGuestUserPrivate({
         // eslint-disable-next-line
         // @ts-ignore
-        mockSlasClientNoSiteID,
+        slasClient: mockSlasClientNoSiteID,
         parameters,
-        credentialsPrivate
-      )
+        credentials: credentialsPrivate,
+      })
     ).rejects.toThrow(
       'Required argument channel_id is not provided through clientConfig.parameters.siteId'
     );
@@ -544,11 +571,11 @@ describe('Registered B2C user flow', () => {
       .post(`/shopper/auth/v1/organizations/${organizationId}/oauth2/login`)
       .reply(303, {response_body: 'response_body'}, {location: url});
 
-    await slasHelper.loginRegisteredUserB2C(
-      mockSlasClient,
+    await slasHelper.loginRegisteredUserB2C({
+      slasClient: mockSlasClient,
       credentials,
-      registeredUserFlowParams
-    );
+      parameters: registeredUserFlowParams,
+    });
 
     expect(getAccessTokenMock).toBeCalledWith(expectedTokenBody);
   });
@@ -566,19 +593,17 @@ describe('Registered B2C user flow', () => {
         return [303, {response_body: 'response_body'}, {location: url}];
       });
 
-    await slasHelper.loginRegisteredUserB2C(
-      mockSlasClient,
+    await slasHelper.loginRegisteredUserB2C({
+      slasClient: mockSlasClient,
       credentials,
-      {
+      parameters: {
         redirectURI: 'redirect_uri',
         dnt: false,
       },
-      {
-        body: {
-          c_body: 'test',
-        },
-      }
-    );
+      body: {
+        c_body: 'test',
+      },
+    });
     expect(getAccessTokenMock).toBeCalledWith(expectedTokenBody);
   });
 
@@ -610,11 +635,11 @@ describe('Registered B2C user flow', () => {
       .post(`/shopper/auth/v1/organizations/${organizationId}/oauth2/login`)
       .reply(303, {response_body: 'response_body'}, {location: url});
 
-    await slasHelper.loginRegisteredUserB2C(
-      mockSlasClient,
-      credentialsPrivate,
-      registeredUserFlowParams
-    );
+    await slasHelper.loginRegisteredUserB2C({
+      slasClient: mockSlasClient,
+      credentials: credentialsPrivate,
+      parameters: registeredUserFlowParams,
+    });
 
     expect(getAccessTokenMock).toBeCalledWith(expectedReqOptions);
   });
@@ -629,11 +654,11 @@ describe('Registered B2C user flow', () => {
       .reply(400, {message: 'Oh no!'});
 
     await expect(
-      slasHelper.loginRegisteredUserB2C(
-        mockSlasClient,
+      slasHelper.loginRegisteredUserB2C({
+        slasClient: mockSlasClient,
         credentials,
-        registeredUserFlowParams
-      )
+        parameters: registeredUserFlowParams,
+      })
     ).rejects.toThrow(ResponseError);
   });
 
@@ -647,11 +672,11 @@ describe('Registered B2C user flow', () => {
       .reply(401, {message: 'Oh no!'});
 
     await expect(
-      slasHelper.loginRegisteredUserB2C(
-        mockSlasClient,
+      slasHelper.loginRegisteredUserB2C({
+        slasClient: mockSlasClient,
         credentials,
-        registeredUserFlowParams
-      )
+        parameters: registeredUserFlowParams,
+      })
     ).rejects.toThrow(ResponseError);
   });
 
@@ -665,11 +690,11 @@ describe('Registered B2C user flow', () => {
       .reply(500, {message: 'Oh no!'});
 
     await expect(
-      slasHelper.loginRegisteredUserB2C(
-        mockSlasClient,
+      slasHelper.loginRegisteredUserB2C({
+        slasClient: mockSlasClient,
         credentials,
-        registeredUserFlowParams
-      )
+        parameters: registeredUserFlowParams,
+      })
     ).rejects.toThrow(ResponseError);
   });
 
@@ -683,11 +708,11 @@ describe('Registered B2C user flow', () => {
       .reply(303, {message: 'Oh yes!'});
 
     await expect(
-      slasHelper.loginRegisteredUserB2C(
-        mockSlasClient,
+      slasHelper.loginRegisteredUserB2C({
+        slasClient: mockSlasClient,
         credentials,
-        registeredUserFlowParams
-      )
+        parameters: registeredUserFlowParams,
+      })
     ).resolves.not.toThrow(ResponseError);
   });
 
@@ -700,11 +725,11 @@ describe('Registered B2C user flow', () => {
       .post(`/shopper/auth/v1/organizations/${organizationId}/oauth2/login`)
       .reply(303, {response_body: 'response_body'}, {location: url});
 
-    const accessToken = await slasHelper.loginRegisteredUserB2C(
-      mockSlasClient,
+    const accessToken = await slasHelper.loginRegisteredUserB2C({
+      slasClient: mockSlasClient,
       credentials,
-      registeredUserFlowParams
-    );
+      parameters: registeredUserFlowParams,
+    });
     expect(accessToken).toStrictEqual(expectedTokenResponse);
   });
 });
@@ -725,11 +750,11 @@ describe('authorizePasswordless is working', () => {
     const authHeaderExpected = `Basic ${slasHelper.stringToBase64(
       `${clientId}:${credentialsPrivate.clientSecret}`
     )}`;
-    await slasHelper.authorizePasswordless(
-      mockSlasClient,
-      credentialsPrivate,
-      parametersAuthorizePasswordless
-    );
+    await slasHelper.authorizePasswordless({
+      slasClient: mockSlasClient,
+      credentials: credentialsPrivate,
+      parameters: parametersAuthorizePasswordless,
+    });
     const expectedReqOptions = {
       headers: {
         Authorization: authHeaderExpected,
@@ -776,11 +801,11 @@ describe('authorizePasswordless is working', () => {
       mode: 'callback',
     };
     await expect(
-      slasHelper.authorizePasswordless(
-        mockSlasClient,
-        credentialsPrivate,
-        parametersAuthorizePasswordless
-      )
+      slasHelper.authorizePasswordless({
+        slasClient: mockSlasClient,
+        credentials: credentialsPrivate,
+        parameters: parametersAuthorizePasswordless,
+      })
     ).rejects.toThrow(
       'Required argument channel_id is not provided through clientConfig.parameters.siteId'
     );
@@ -795,13 +820,13 @@ describe('authorizePasswordless is working', () => {
       locale: 'a_locale',
     };
     await expect(
-      slasHelper.authorizePasswordless(
-        mockSlasClient,
-        credentialsPrivate,
+      slasHelper.authorizePasswordless({
+        slasClient: mockSlasClient,
+        credentials: credentialsPrivate,
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore intentionally missing mode
-        parametersAuthorizePasswordless
-      )
+        parameters: parametersAuthorizePasswordless,
+      })
     ).rejects.toThrow(
       'Required argument mode is not provided through parameters'
     );
@@ -817,16 +842,16 @@ describe('authorizePasswordless is working', () => {
       mode: 'callback',
     };
     await expect(
-      slasHelper.authorizePasswordless(
-        mockSlasClient,
-        {
+      slasHelper.authorizePasswordless({
+        slasClient: mockSlasClient,
+        credentials: {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore intentionally missing mode
           username: 'Jeff',
           password: 'password',
         },
-        parametersAuthorizePasswordless
-      )
+        parameters: parametersAuthorizePasswordless,
+      })
     ).rejects.toThrow('Required argument client secret is not provided');
   });
 });
@@ -843,11 +868,11 @@ describe('getPasswordLessAccessToken is working', () => {
     const authHeaderExpected = `Basic ${slasHelper.stringToBase64(
       `${clientId}:${credentialsPrivate.clientSecret}`
     )}`;
-    await slasHelper.getPasswordLessAccessToken(
-      mockSlasClient,
-      credentialsPrivate,
-      parametersPasswordlessToken
-    );
+    await slasHelper.getPasswordLessAccessToken({
+      slasClient: mockSlasClient,
+      credentials: credentialsPrivate,
+      parameters: parametersPasswordlessToken,
+    });
     const expectedReqOptions = {
       headers: {
         Authorization: authHeaderExpected,
@@ -886,11 +911,11 @@ describe('getPasswordLessAccessToken is working', () => {
       dnt: '1',
     };
     await expect(
-      slasHelper.getPasswordLessAccessToken(
-        mockSlasClient,
-        credentialsPrivate,
-        parametersPasswordlessToken
-      )
+      slasHelper.getPasswordLessAccessToken({
+        slasClient: mockSlasClient,
+        credentials: credentialsPrivate,
+        parameters: parametersPasswordlessToken,
+      })
     ).rejects.toThrow(
       'Required argument organizationId is not provided through clientConfig.parameters.organizationId'
     );
@@ -908,10 +933,10 @@ describe('Refresh Token', () => {
         dnt: 'false',
       },
     };
-    const token = slasHelper.refreshAccessToken(
-      createMockSlasClient(),
-      parameters
-    );
+    const token = slasHelper.refreshAccessToken({
+      slasClient: createMockSlasClient(),
+      parameters,
+    });
     expect(getAccessTokenMock).toBeCalledWith(expectedBody);
     expect(token).toStrictEqual(expectedTokenResponse);
   });
@@ -931,13 +956,13 @@ describe('Refresh Token', () => {
         dnt: 'false',
       },
     };
-    const token = slasHelper.refreshAccessToken(
-      createMockSlasClient(),
+    const token = slasHelper.refreshAccessToken({
+      slasClient: createMockSlasClient(),
       parameters,
-      {
+      credentials: {
         clientSecret: credentialsPrivate.clientSecret,
-      }
-    );
+      },
+    });
     expect(getAccessTokenMock).toBeCalledWith(expectedReqOpts);
     expect(token).toStrictEqual(expectedTokenResponse);
   });
@@ -956,7 +981,10 @@ describe('Logout', () => {
   };
 
   test('logs out the customer', () => {
-    const token = slasHelper.logout(createMockSlasClient(), parameters);
+    const token = slasHelper.logout({
+      slasClient: createMockSlasClient(),
+      parameters,
+    });
     expect(logoutCustomerMock).toBeCalledWith(expectedOptions);
     expect(token).toStrictEqual(expectedTokenResponse);
   });

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -221,12 +221,10 @@ export async function authorizeIDP(options: {
     clientOptions.codeChallenge = await generateCodeChallenge(codeVerifier);
   }
 
-  // eslint-disable-next-line
   const apiPath = ShopperLogin.apiPaths.authorizeCustomer;
   const pathParams: ShopperLoginPathParameters & Required<BaseUriParameters> = {
     organizationId: slasClient.clientConfig.parameters.organizationId,
     shortCode: slasClient.clientConfig.parameters.shortCode,
-    version: slasClient.clientConfig.parameters.version || 'v1',
   };
   const queryParams: ShopperLoginQueryParameters = {
     // put it at the top to avoid overriding the rest of params

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -110,21 +110,23 @@ export const generateCodeChallenge = async (
  * @param privateClient? - flag to indicate if the client is private or not. Defaults to false.
  * @returns login url, user id and authorization code if available
  */
-export async function authorize(
+export async function authorize(options: {
   slasClient: ShopperLogin<{
     shortCode: string;
     organizationId: string;
     clientId: string;
     siteId: string;
-  }>,
-  codeVerifier: string,
+  }>;
+  codeVerifier: string;
   parameters: {
     redirectURI: string;
     hint?: string;
     usid?: string;
-  } & CustomQueryParameters,
-  privateClient = false
-): Promise<{code: string; url: string; usid: string}> {
+  } & CustomQueryParameters;
+  privateClient?: boolean;
+}): Promise<{code: string; url: string; usid: string}> {
+  const {slasClient, codeVerifier, parameters, privateClient = false} = options;
+
   interface ClientOptions {
     codeChallenge?: string;
   }
@@ -193,21 +195,22 @@ export async function authorize(
  * @param privateClient - boolean indicating whether the client is private or not. Defaults to false.
  * @returns authorization url and code verifier
  */
-export async function authorizeIDP(
+export async function authorizeIDP(options: {
   slasClient: ShopperLogin<{
     shortCode: string;
     organizationId: string;
     clientId: string;
     siteId: string;
     version?: string;
-  }>,
+  }>;
   parameters: {
     redirectURI: string;
     hint: string;
     usid?: string;
-  } & CustomQueryParameters,
-  privateClient = false
-): Promise<{url: string; codeVerifier: string}> {
+  } & CustomQueryParameters;
+  privateClient?: boolean;
+}): Promise<{url: string; codeVerifier: string}> {
+  const {slasClient, parameters, privateClient = false} = options;
   const {hint, redirectURI, usid, ...restOfParams} = parameters;
   const codeVerifier = createCodeVerifier();
   interface ClientOptions {
@@ -261,24 +264,25 @@ export async function authorizeIDP(
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
  * @returns TokenResponse
  */
-export async function loginIDPUser(
+export async function loginIDPUser(options: {
   slasClient: ShopperLogin<{
     shortCode: string;
     organizationId: string;
     clientId: string;
     siteId: string;
-  }>,
+  }>;
   credentials: {
     clientSecret?: string;
     codeVerifier?: string;
-  },
+  };
   parameters: {
     redirectURI: string;
     code: string;
     usid?: string;
     dnt?: boolean;
-  }
-): Promise<TokenResponse> {
+  };
+}): Promise<TokenResponse> {
+  const {slasClient, credentials, parameters} = options;
   const privateClient = !!credentials.clientSecret;
 
   const tokenBody = {
@@ -324,21 +328,22 @@ export async function loginIDPUser(
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
  * @returns TokenResponse
  */
-export async function loginGuestUserPrivate(
+export async function loginGuestUserPrivate(options: {
   slasClient: ShopperLogin<{
     shortCode: string;
     organizationId: string;
     clientId: string;
     siteId: string;
-  }>,
+  }>;
   parameters: {
     usid?: string;
     dnt?: boolean;
-  },
+  };
   credentials: {
     clientSecret: string;
-  }
-): Promise<TokenResponse> {
+  };
+}): Promise<TokenResponse> {
+  const {slasClient, parameters, credentials} = options;
   if (!slasClient.clientConfig.parameters.siteId) {
     throw new Error(
       'Required argument channel_id is not provided through clientConfig.parameters.siteId'
@@ -349,7 +354,7 @@ export async function loginGuestUserPrivate(
     `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
   )}`;
 
-  const options = {
+  const opts = {
     headers: {
       Authorization: authorization,
     },
@@ -361,7 +366,7 @@ export async function loginGuestUserPrivate(
     },
   };
 
-  return slasClient.getAccessToken(options);
+  return slasClient.getAccessToken(opts);
 }
 
 /**
@@ -373,26 +378,27 @@ export async function loginGuestUserPrivate(
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
  * @returns TokenResponse
  */
-export async function loginGuestUser(
+export async function loginGuestUser(options: {
   slasClient: ShopperLogin<{
     shortCode: string;
     organizationId: string;
     clientId: string;
     siteId: string;
-  }>,
+  }>;
   parameters: {
     redirectURI: string;
     usid?: string;
     dnt?: boolean;
-  } & CustomQueryParameters
-): Promise<TokenResponse> {
+  } & CustomQueryParameters;
+}): Promise<TokenResponse> {
+  const {slasClient, parameters} = options;
   const codeVerifier = createCodeVerifier();
 
   const {dnt, redirectURI, usid, ...restOfParams} = parameters;
-  const authResponse = await authorize(
+  const authResponse = await authorize({
     slasClient,
     codeVerifier,
-    {
+    parameters: {
       // putting this at the top to avoid any overriding on the required query param below
       // since they are not supposed to be overridden via helpers
       ...restOfParams,
@@ -400,8 +406,8 @@ export async function loginGuestUser(
       hint: 'guest',
       ...(usid && {usid}),
     },
-    false
-  );
+    privateClient: false,
+  });
   const tokenBody = {
     client_id: slasClient.clientConfig.parameters.clientId,
     channel_id: slasClient.clientConfig.parameters.siteId,
@@ -432,27 +438,26 @@ export async function loginGuestUser(
  * @param options.body - optional body parameters to pass in the ShopperLogin 'authenticateCustomer' method.
  * @returns TokenResponse
  */
-export async function loginRegisteredUserB2C(
+export async function loginRegisteredUserB2C(options: {
   slasClient: ShopperLogin<{
     shortCode: string;
     organizationId: string;
     clientId: string;
     siteId: string;
-  }>,
+  }>;
   credentials: {
     username: string;
     password: string;
     clientSecret?: string;
-  },
+  };
   parameters: {
     redirectURI: string;
     usid?: string;
     dnt?: boolean;
-  },
-  options?: {
-    body?: CustomRequestBody;
-  }
-): Promise<TokenResponse> {
+  };
+  body?: CustomRequestBody;
+}): Promise<TokenResponse> {
+  const {slasClient, credentials, parameters, body} = options;
   const codeVerifier = createCodeVerifier();
   const codeChallenge = await generateCodeChallenge(codeVerifier);
 
@@ -480,7 +485,7 @@ export async function loginRegisteredUserB2C(
       organizationId: slasClient.clientConfig.parameters.organizationId,
     },
     body: {
-      ...(options?.body || {}),
+      ...(body || {}),
       redirect_uri: redirectURI,
       client_id: slasClient.clientConfig.parameters.clientId,
       code_challenge: codeChallenge,
@@ -541,24 +546,25 @@ export async function loginRegisteredUserB2C(
  * @param parameters.mode - Medium of sending login token
  * @returns Promise of Response
  */
-export async function authorizePasswordless(
+export async function authorizePasswordless(options: {
   slasClient: ShopperLogin<{
     shortCode: string;
     organizationId: string;
     clientId: string;
     siteId: string;
-  }>,
+  }>;
   credentials: {
     clientSecret: string;
-  },
+  };
   parameters: {
     callbackURI?: string;
     usid?: string;
     userid: string;
     locale?: string;
     mode: string;
-  }
-): Promise<Response> {
+  };
+}): Promise<Response> {
+  const {slasClient, credentials, parameters} = options;
   if (!credentials.clientSecret) {
     throw new Error('Required argument client secret is not provided');
   }
@@ -615,21 +621,22 @@ export async function authorizePasswordless(
  * @param parameters.dnt? - Optional parameter to enable Do Not Track (DNT) for the user.
  * @returns Promise of Response or Object
  */
-export async function getPasswordLessAccessToken(
+export async function getPasswordLessAccessToken(options: {
   slasClient: ShopperLogin<{
     shortCode: string;
     organizationId: string;
     clientId: string;
     siteId: string;
-  }>,
+  }>;
   credentials: {
     clientSecret: string;
-  },
+  };
   parameters: {
     pwdlessLoginToken: string;
     dnt?: string;
-  }
-): Promise<TokenResponse> {
+  };
+}): Promise<TokenResponse> {
+  const {slasClient, credentials, parameters} = options;
   if (!credentials.clientSecret) {
     throw new Error('Required argument client secret is not provided');
   }
@@ -676,19 +683,20 @@ export async function getPasswordLessAccessToken(
  * @param credentials.clientSecret - secret associated with client ID
  * @returns TokenResponse
  */
-export function refreshAccessToken(
+export function refreshAccessToken(options: {
   slasClient: ShopperLogin<{
     shortCode: string;
     organizationId: string;
     clientId: string;
     siteId: string;
-  }>,
+  }>;
   parameters: {
     refreshToken: string;
     dnt?: boolean;
-  },
-  credentials?: {clientSecret?: string}
-): Promise<TokenResponse> {
+  };
+  credentials?: {clientSecret?: string};
+}): Promise<TokenResponse> {
+  const {slasClient, parameters, credentials} = options;
   const body = {
     grant_type: 'refresh_token' as const,
     refresh_token: parameters.refreshToken,
@@ -701,13 +709,13 @@ export function refreshAccessToken(
     const authorization = `Basic ${stringToBase64(
       `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
     )}`;
-    const options = {
+    const opts = {
       headers: {
         Authorization: authorization,
       },
       body,
     };
-    return slasClient.getAccessToken(options);
+    return slasClient.getAccessToken(opts);
   }
 
   return slasClient.getAccessToken({body});
@@ -721,18 +729,19 @@ export function refreshAccessToken(
  * @param parameters.refreshToken - a valid refresh token to exchange for a new access token (and refresh token).
  * @returns TokenResponse
  */
-export function logout(
+export function logout(options: {
   slasClient: ShopperLogin<{
     shortCode: string;
     organizationId: string;
     clientId: string;
     siteId: string;
-  }>,
+  }>;
   parameters: {
     accessToken: string;
     refreshToken: string;
-  }
-): Promise<TokenResponse> {
+  };
+}): Promise<TokenResponse> {
+  const {slasClient, parameters} = options;
   return slasClient.logoutCustomer({
     headers: {
       Authorization: `Bearer ${parameters.accessToken}`,

--- a/src/static/helpers/types.ts
+++ b/src/static/helpers/types.ts
@@ -38,7 +38,6 @@ export type RequireParametersUnlessAllAreOptional<
  */
 export interface BaseUriParameters {
   shortCode: string;
-  version?: string; // Optional, will default to "v1" if not provided.
 }
 
 export type LocaleCode = {[key: string]: any};

--- a/src/static/templateUrl.test.ts
+++ b/src/static/templateUrl.test.ts
@@ -145,3 +145,38 @@ it.each([
 ])('Normalize %s path', (url, base, parameters, expected) => {
   expect(new TemplateURL(url, base, parameters).toString()).toBe(expected);
 });
+
+it.each([
+  [
+    'path/with spaces',
+    'https://example.com',
+    {},
+    'https://example.com/path/with%20spaces',
+  ],
+  [
+    'path/with/special&chars',
+    'https://example.com',
+    {},
+    'https://example.com/path/with/special%26chars',
+  ],
+  [
+    'path/with/unicode/测试',
+    'https://example.com',
+    {},
+    'https://example.com/path/with/unicode/%E6%B5%8B%E8%AF%95',
+  ],
+  [
+    'path/with/multiple/special/chars!@#$%^&*()',
+    'https://example.com',
+    {},
+    'https://example.com/path/with/multiple/special/chars!%40%23%24%25%5E%26*()',
+  ],
+  [
+    'path/with/{special}/chars',
+    'https://example.com',
+    {pathParams: {special: 'test!@#$%'}},
+    'https://example.com/path/with/test!%40%23%24%25/chars',
+  ],
+])('Handles special characters in path: %s', (url, base, parameters, expected) => {
+  expect(new TemplateURL(url, base, parameters).toString()).toBe(expected);
+});

--- a/src/static/templateUrl.test.ts
+++ b/src/static/templateUrl.test.ts
@@ -6,10 +6,6 @@
  */
 import TemplateURL from './templateUrl';
 
-// TODO: add unit tests for templateURL
-// Update README.md with new example
-// Update CHANGELOG
-
 it.each([
   ['simple', 'http://example.com', 'http://example.com/simple'],
   ['simple', 'https://example.com', 'https://example.com/simple'],

--- a/src/static/templateUrl.test.ts
+++ b/src/static/templateUrl.test.ts
@@ -6,6 +6,8 @@
  */
 import TemplateURL from './templateUrl';
 
+// TODO: add unit tests for templateURL
+
 it.each([
   ['simple', 'http://example.com', 'http://example.com/simple'],
   ['simple', 'https://example.com', 'https://example.com/simple'],

--- a/src/static/templateUrl.test.ts
+++ b/src/static/templateUrl.test.ts
@@ -173,6 +173,9 @@ it.each([
     {pathParams: {special: 'test!@#$%'}},
     'https://example.com/path/with/test!%40%23%24%25/chars',
   ],
-])('Handles special characters in path: %s', (url, base, parameters, expected) => {
-  expect(new TemplateURL(url, base, parameters).toString()).toBe(expected);
-});
+])(
+  'Handles special characters in path: %s',
+  (url, base, parameters, expected) => {
+    expect(new TemplateURL(url, base, parameters).toString()).toBe(expected);
+  }
+);

--- a/src/static/templateUrl.test.ts
+++ b/src/static/templateUrl.test.ts
@@ -7,6 +7,8 @@
 import TemplateURL from './templateUrl';
 
 // TODO: add unit tests for templateURL
+// Update README.md with new example
+// Update CHANGELOG
 
 it.each([
   ['simple', 'http://example.com', 'http://example.com/simple'],

--- a/src/static/templateUrl.ts
+++ b/src/static/templateUrl.ts
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import type {PathParameters, QueryParameters} from './helpers/types';
+import { encodeSCAPISpecialCharacters } from './helpers/fetchHelper';
 
 export default class TemplateURL extends URL {
   /**
@@ -20,10 +21,19 @@ export default class TemplateURL extends URL {
       origin?: string;
     }
   ) {
+    const encodedPathParams: PathParameters = {};
+    
+    Object.keys(parameters?.pathParams || {}).forEach(key => {
+      const value = parameters?.pathParams?.[key];
+      if (value) {
+        encodedPathParams[key] = typeof value === 'string' ? encodeSCAPISpecialCharacters(value) : value;
+      }
+    });
+
     super(
       TemplateURL.renderTemplateUri(
         `${base}/${url}`.replace(/\/\/+/g, '/'),
-        parameters?.pathParams
+        encodedPathParams
       )
     );
     this.addQueryParams(parameters?.queryParams);

--- a/src/static/templateUrl.ts
+++ b/src/static/templateUrl.ts
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import type {PathParameters, QueryParameters} from './helpers/types';
-import { encodeSCAPISpecialCharacters } from './helpers/fetchHelper';
 
 export default class TemplateURL extends URL {
   /**
@@ -22,11 +21,11 @@ export default class TemplateURL extends URL {
     }
   ) {
     const encodedPathParams: PathParameters = {};
-    
+
     Object.keys(parameters?.pathParams || {}).forEach(key => {
       const value = parameters?.pathParams?.[key];
       if (value) {
-        encodedPathParams[key] = typeof value === 'string' ? encodeSCAPISpecialCharacters(value) : value;
+        encodedPathParams[key] = encodeURIComponent(value);
       }
     });
 

--- a/templatesOas/apis.mustache
+++ b/templatesOas/apis.mustache
@@ -6,6 +6,7 @@ import { doFetch } from "../../helpers/fetchHelper";
 import type {
     BaseUriParameters,
     CompositeParameters,
+    CustomRequestBody,
     QueryParameters,
     RequireParametersUnlessAllAreOptional,
 } from "../../helpers/types";
@@ -93,6 +94,20 @@ export type {{#lambda.titlecase}}{{#lambda.camelcase}}{{appName}}{{/lambda.camel
  */
 export type {{#lambda.titlecase}}{{#lambda.camelcase}}{{appName}}{{/lambda.camelcase}}{{/lambda.titlecase}}Parameters = {{#lambda.titlecase}}{{#lambda.camelcase}}{{appName}}{{/lambda.camelcase}}{{/lambda.titlecase}}PathParameters & BaseUriParameters & {{#lambda.titlecase}}{{#lambda.camelcase}}{{appName}}{{/lambda.camelcase}}{{/lambda.titlecase}}QueryParameters;
 
+{{#operations}}
+{{#operation}}
+{{#hasFormParams}}
+export type {{nickname}}BodyType = {
+    {{#formParams}}
+    {{#isFormParam}}
+    {{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{dataType}}}{{/isEnum}}{{^isEnum}}{{^isDateTime}}{{^isDate}}{{{dataType}}}{{/isDate}}{{/isDateTime}}{{#isDateTime}}string{{/isDateTime}}{{#isDate}}string{{/isDate}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}};
+    {{/isFormParam}}
+    {{/formParams}}
+}
+
+{{/hasFormParams}}
+{{/operation}}
+{{/operations}}
 /**
 * [{{appName}}](https://developer.salesforce.com/docs/commerce/commerce-api/references?meta={{#lambda.kebabcase}}{{appName}}{{/lambda.kebabcase}}:Summary)
 * ==================================
@@ -222,18 +237,12 @@ export class {{#vendorExtensions}}{{#x-sdk-classname}}{{{ . }}}{{/x-sdk-classnam
             headers?: { [key: string]: string },
             {{#hasBodyParam}}
             {{#bodyParam}}
-            body: {{{dataType}}}
+            body: {{{dataType}}} & CustomRequestBody
             {{/bodyParam}}
             {{/hasBodyParam}}
             {{^hasBodyParam}}
             {{#hasFormParams}}
-            body: {
-            {{#formParams}}
-            {{#isFormParam}}
-                {{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{dataType}}}{{/isEnum}}{{^isEnum}}{{^isDateTime}}{{^isDate}}{{{dataType}}}{{/isDate}}{{/isDateTime}}{{#isDateTime}}string{{/isDateTime}}{{#isDate}}string{{/isDate}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}};
-            {{/isFormParam}}
-            {{/formParams}}
-            }
+            body: {{nickname}}BodyType & CustomRequestBody
             {{/hasFormParams}}
             {{/hasBodyParam}}
         }>
@@ -287,18 +296,12 @@ export class {{#vendorExtensions}}{{#x-sdk-classname}}{{{ . }}}{{/x-sdk-classnam
             headers?: { [key: string]: string },
             {{#hasBodyParam}}
             {{#bodyParam}}
-            body: {{{dataType}}}
+            body: {{{dataType}}} & CustomRequestBody
             {{/bodyParam}}
             {{/hasBodyParam}}
             {{^hasBodyParam}}
             {{#hasFormParams}}
-            body: {
-            {{#formParams}}
-            {{#isFormParam}}
-                {{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{dataType}}}{{/isEnum}}{{^isEnum}}{{^isDateTime}}{{^isDate}}{{{dataType}}}{{/isDate}}{{/isDateTime}}{{#isDateTime}}string{{/isDateTime}}{{#isDate}}string{{/isDate}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}};
-            {{/isFormParam}}
-            {{/formParams}}
-            }
+            body: {{nickname}}BodyType & CustomRequestBody
             {{/hasFormParams}}
             {{/hasBodyParam}}
         }>,
@@ -353,18 +356,12 @@ export class {{#vendorExtensions}}{{#x-sdk-classname}}{{{ . }}}{{/x-sdk-classnam
             headers?: { [key: string]: string },
             {{#hasBodyParam}}
             {{#bodyParam}}
-            body: {{{dataType}}}
+            body: {{{dataType}}} & CustomRequestBody
             {{/bodyParam}}
             {{/hasBodyParam}}
             {{^hasBodyParam}}
             {{#hasFormParams}}
-            body: {
-            {{#formParams}}
-            {{#isFormParam}}
-                {{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{dataType}}}{{/isEnum}}{{^isEnum}}{{^isDateTime}}{{^isDate}}{{{dataType}}}{{/isDate}}{{/isDateTime}}{{#isDateTime}}string{{/isDateTime}}{{#isDate}}string{{/isDate}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}};
-            {{/isFormParam}}
-            {{/formParams}}
-            }
+            body: {{nickname}}BodyType & CustomRequestBody
             {{/hasFormParams}}
             {{/hasBodyParam}}
         }>,
@@ -375,7 +372,6 @@ export class {{#vendorExtensions}}{{#x-sdk-classname}}{{{ . }}}{{/x-sdk-classnam
         
         const pathParams: {{#lambda.titlecase}}{{#lambda.camelcase}}{{appName}}{{/lambda.camelcase}}{{/lambda.titlecase}}PathParameters & Required<BaseUriParameters> = {
           shortCode: configParams.shortCode,
-          version: configParams.version || "v1"
         };
 
         {{#pathParams}}

--- a/templatesOas/index.mustache
+++ b/templatesOas/index.mustache
@@ -26,6 +26,9 @@ export namespace {{#apiInfo}}{{#apis.0}}{{#vendorExtensions}}{{#x-sdk-classname}
     {{/stringEnums}}
     {{/isEnum}}
     {{/allParams}}
+    {{#hasFormParams}}
+    export type {{nickname}}BodyType = {{#lambda.titlecase}}{{#lambda.camelcase}}{{appName}}{{/lambda.camelcase}}{{/lambda.titlecase}}ApiTypes.{{nickname}}BodyType
+    {{/hasFormParams}}
     export type {{nickname}}QueryParameters = {{#lambda.titlecase}}{{#lambda.camelcase}}{{appName}}{{/lambda.camelcase}}{{/lambda.titlecase}}ApiTypes.{{nickname}}QueryParameters
     export type {{nickname}}PathParameters = {{#lambda.titlecase}}{{#lambda.camelcase}}{{appName}}{{/lambda.camelcase}}{{/lambda.titlecase}}ApiTypes.{{nickname}}PathParameters
     {{/operation}}


### PR DESCRIPTION
This PR adds a number of refactors:
- SLAS helpers take in 1 options object instead of multiple positional arguments
- Path parameters are encoded by default
- Form parameters have been refactored into a reusable type
- All endpoints accept `c_` custom properties for request body
- API version as client config property has been removed