### PR TITLE
Fix: require is not defined node-fetch (@W-19399622@)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v4.1.0
+
+### Fixes
+- Use native node fetch available in node 18+ instead of `node-fetch` polyfill [#214](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/214)
+
 ## v4.0.0
 
 ### API Versions

--- a/README.md
+++ b/README.md
@@ -51,13 +51,15 @@ In the next major version release, the SDK will encode special characters (UTF-8
 
 ### Requirements
 
-- Node `^12.x`, `^14.x`, `^16.x`, `^18.x`
+- Node `^20.x` or `^22.x`
 - The SDK requires B2C Commerce API (SCAPI) to be configured. For more info see [Getting started with SCAPI](https://developer.salesforce.com/docs/commerce/commerce-api/guide/get-started.html).
 
 ### Installation
 
 ```bash
-npm install commerce-sdk-isomorphic
+# This package uses yarn, if you don't have yarn:
+# npm install -g yarn
+yarn install commerce-sdk-isomorphic
 ```
 
 ### Usage

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+module.exports = {
+  setupFilesAfterEnv: ['<rootDir>/src/test/setupTests.ts'],
+  collectCoverageFrom: [
+    'src/static/**/*.{js,jsx,ts,tsx}',
+    'scripts/**/*.{js,jsx,ts,tsx}',
+    '!scripts/generate.ts',
+    '!scripts/updateApis.ts',
+    '!scripts/generateVersionTable.ts',
+    '!<rootDir>/node_modules/',
+  ],
+  coverageReporters: ['text'],
+  coverageThreshold: {
+    global: {
+      branches: 90,
+      functions: 90,
+      lines: 90,
+      statements: 90,
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -69,27 +69,6 @@
       "last 1 safari version"
     ]
   },
-  "jest": {
-    "collectCoverageFrom": [
-      "src/static/**/*.{js,jsx,ts,tsx}",
-      "scripts/**/*.{js,jsx,ts,tsx}",
-      "!scripts/generate.ts",
-      "!scripts/updateApis.ts",
-      "!scripts/generateVersionTable.ts",
-      "!<rootDir>/node_modules/"
-    ],
-    "coverageReporters": [
-      "text"
-    ],
-    "coverageThreshold": {
-      "global": {
-        "branches": 90,
-        "functions": 90,
-        "lines": 90,
-        "statements": 90
-      }
-    }
-  },
   "resolutions": {
     "**/@npmcli/fs": "<1.1.0",
     "**/@oclif/command": "<=1.8.3",
@@ -100,7 +79,6 @@
   },
   "dependencies": {
     "nanoid": "^3.3.8",
-    "node-fetch": "2.6.13",
     "seedrandom": "^3.0.5"
   },
   "devDependencies": {
@@ -143,6 +121,7 @@
     "jest-environment-jsdom-sixteen": "1.0.3",
     "lint-staged": "10.5.4",
     "nock": "^13.2.8",
+    "node-fetch": "2.6.13",
     "npm-pack-all": "^1.12.7",
     "postcss-preset-env": "6.7.1",
     "prettier": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "start": "HTTPS=true react-scripts start",
     "pretest": "yarn run lint && yarn run lint:style && depcheck && yarn run check:size",
     "test": "yarn run check:types && yarn run test:unit && CI=true yarn run test:react",
-    "test:react": "react-scripts test --env=jest-environment-jsdom-sixteen src/environment",
+    "test:react": "react-scripts test --env=jest-environment-jsdom-sixteen src/environment --setupFilesAfterEnv ./src/test/setupTests.ts",
     "test:unit": "jest --coverage --testPathIgnorePatterns node_modules src/environment --silent",
     "updateApis": "ts-node --compiler-options '{\"module\": \"commonjs\", \"target\": \"ES6\" }' ./scripts/updateApis.ts && yarn diffApis"
   },

--- a/src/static/helpers/environment.ts
+++ b/src/static/helpers/environment.ts
@@ -20,24 +20,17 @@ export const isNode =
   typeof process.versions === 'object' &&
   typeof process.versions.node === 'string';
 
-export const globalObject = isBrowser ? window : globalThis;
+export const globalObject = isBrowser ? window : globalThis || global;
 
 export const hasFetchAvailable = typeof globalObject.fetch === 'function';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 export const fetch: FetchFunction = (() => {
-  if (isNode) {
-    // .default is added because the newer versions of babel doesn't get the default export automatically for require().
-    // eslint-disable-next-line global-require, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-member-access
-    return require('node-fetch').default;
-  }
-
-  // difficult to test in node environment
+  // Difficult to test in node environment
   /* istanbul ignore next */
-  if (!hasFetchAvailable)
-    throw new Error(
-      'Bad environment: it is not a node environment but fetch is not defined'
-    );
+  if (!hasFetchAvailable) {
+    throw new Error('Please use Node.js 18+ for native fetch support.');
+  }
 
   return globalObject.fetch;
 })();

--- a/src/static/helpers/environment.ts
+++ b/src/static/helpers/environment.ts
@@ -20,7 +20,7 @@ export const isNode =
   typeof process.versions === 'object' &&
   typeof process.versions.node === 'string';
 
-export const globalObject = isBrowser ? window : globalThis || global;
+export const globalObject = isBrowser ? window : globalThis;
 
 export const hasFetchAvailable = typeof globalObject.fetch === 'function';
 

--- a/src/static/helpers/environment.ts
+++ b/src/static/helpers/environment.ts
@@ -24,6 +24,7 @@ export const globalObject = isBrowser ? window : globalThis;
 
 export const hasFetchAvailable = typeof globalObject.fetch === 'function';
 
+// TODO: Remove this function in the next major version
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 export const fetch: FetchFunction = (() => {
   // Difficult to test in node environment

--- a/src/static/helpers/fetchHelper.test.ts
+++ b/src/static/helpers/fetchHelper.test.ts
@@ -80,7 +80,7 @@ describe('doFetch', () => {
       .query({siteId: 'site_id'})
       .reply(200, responseBody);
 
-    const spy = jest.spyOn(environment, 'fetch');
+    const spy = jest.spyOn(global, 'fetch');
 
     const response = await doFetch(url, copyOptions, copyClientConfig);
     expect(response).toEqual(responseBody);
@@ -130,7 +130,7 @@ describe('doFetch', () => {
   test('passes on fetchOptions from clientConfig to fetch call', async () => {
     nock(basePath).post(endpointPath).query(true).reply(200, responseBody);
 
-    const spy = jest.spyOn(environment, 'fetch');
+    const spy = jest.spyOn(global, 'fetch');
     await doFetch(url, options, clientConfig, false);
     expect(spy).toBeCalledTimes(1);
     expect(spy).toBeCalledWith(

--- a/src/static/helpers/fetchHelper.ts
+++ b/src/static/helpers/fetchHelper.ts
@@ -8,7 +8,6 @@ import {BodyInit} from 'node-fetch';
 import {BaseUriParameters} from '.';
 import type {FetchOptions} from '../clientConfig';
 import ResponseError from '../responseError';
-import {fetch} from './environment';
 import {ClientConfigInit} from '../clientConfig';
 
 /**

--- a/src/test/setupTests.ts
+++ b/src/test/setupTests.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+// Import node-fetch polyfill for Jest tests
+import fetch from 'node-fetch';
+
+// Make fetch available globally for tests
+// eslint-disable-next-line
+(global as any).fetch = fetch;


### PR DESCRIPTION
With the latest major version release, we dropped official support for older node versions and only support node versions 20 & 22. With these versions, node exposes a native fetch function which means we can replace our `node-fetch` polyfill.  This helps resolve an issue with one of our other projects that uses ESM and runs into the following error due to us using `require('node-fetch')` in `environment.ts`:
```
ReferenceError: require is not defined
```

## Changes
1. The `doFetch` function in `src/static/helpers/fetchHelper.ts` that is used by all endpoints will be calling the node/browser fetch instead of the one defined in `src/static/helpers/environment.ts`
    - We unfortunately can't remove the `fetch` function and other unused variables in `environment.ts` as we've already exposed them and removing them would technically be a breaking change. I've added a note to remove them for the next major version bump.
3. Due to the change above, our current testing environments don't expose a fetch function and tests run into an error where no fetch function is defined, so I've updated the test environments to run a setup file to add a fetch polyfill
    - I took a quick stab at trying to just update all of our test dependencies to be on more recent versions to see if newer packages expose a fetch function that the test suites could use, but I think the work is more than expected and so I decided to go with the polyfill approach for now and we can create a follow up ticket to update the testing dependencies

## How to test

You can test this by making API calls both on the browser and the server and ensure things work as expected.

1. In your local version of isomorphic SDK: `git checkout ju/fix-node-fetch`
2. `yarn install && yarn renderTemplates && yarn build:lib`

### Browser

Reach out to me for details as we'll be testing with the new project

### Server

1. If you don't already have a project set up for testing the SDKs, create a new node project with `npm init -y`
4. Add a local reference to the `commerce-sdk-isomorphic` in your `package.json`. The example below uses an absolute path, you can also use relative pathing or symlink with `npm link`
5. `npm install` in testing project

```
  "dependencies": {
    "commerce-sdk-isomorphic": "/Users/joel.uong/Desktop/workspace/commerce-sdk-isomorphic",
  }
```

3. Add an `index.js` file and add the following code, replacing the client config variables:

```javascript
import pkg from 'commerce-sdk-isomorphic';
const { helpers, ShopperLogin, ShopperSearch } = pkg;

// demo client credentials, if you have access to your own please replace them below.
const CLIENT_ID = "<INSERT_CLIENT_ID>";
const ORG_ID = "<INSERT_ORG_ID>";
const SHORT_CODE = "<INSERT_SHORT_CODE>";
const SITE_ID = "<INSERT_SITE_ID>";

// must be registered in SLAS. On server, redirectURI is never called
const redirectURI = "http://localhost:3000/callback";

// client configuration parameters
const clientConfig = {
  parameters: {
    clientId: CLIENT_ID,
    organizationId: ORG_ID,
    shortCode: SHORT_CODE,
    siteId: SITE_ID,
  },
};

const slasClient = new ShopperLogin(clientConfig);

const guestTokenResponse = await helpers
  .loginGuestUser({
    slasClient, 
    parameters: { redirectURI }
  })
  .then((guestTokenResponse) => {
    console.log("Guest Token Response: ", guestTokenResponse);
    return guestTokenResponse;
  })
  .catch((error) =>
    console.log("Error fetching token for guest login: ", error)
  );

console.log("guestTokenResponse", guestTokenResponse);

const shopperSearch = new ShopperSearch({
  ...clientConfig,
  headers: {authorization: `Bearer ${guestTokenResponse.access_token}`}
});


const searchResults = await shopperSearch.productSearch({
  parameters: {
      q: 'mens shirt',
  }
})

console.log("searchResults: ", searchResults)
```

4. Run `node index.js &> out.txt` and expect that `out.txt` has the expected output