### PR TITLE
@W-21076912: Feat: Support enableHttpOnlySessionCookies in SLAS helper functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
   "bundlesize": [
     {
       "path": "lib/**/*.js",
-      "maxSize": "57 kB"
+      "maxSize": "58 kB"
     },
     {
       "path": "commerce-sdk-isomorphic-with-deps.tgz",

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -62,13 +62,9 @@ const createMockResponse = (
     status: 200,
     text: jest.fn().mockResolvedValue(JSON.stringify(body)),
     headers: {
-      get: jest.fn((name: string) =>
-        name === 'set-cookie' && setCookieHeaders
-          ? setCookieHeaders.join(', ')
-          : null
-      ),
-      getSetCookie: setCookieHeaders
-        ? jest.fn(() => setCookieHeaders)
+      get: jest.fn(() => null),
+      raw: setCookieHeaders
+        ? jest.fn(() => ({'set-cookie': setCookieHeaders}))
         : undefined,
     },
   } as unknown as Response);

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -949,6 +949,27 @@ describe('authorizePasswordless is working', () => {
     );
   });
 
+  test('Throw when required userid missing', async () => {
+    const mockSlasClient = createMockSlasClient();
+    const parametersAuthorizePasswordless = {
+      callbackURI: 'www.something.com/callback',
+      usid: 'a_usid',
+      locale: 'a_locale',
+      mode: 'callback',
+    };
+    await expect(
+      slasHelper.authorizePasswordless({
+        slasClient: mockSlasClient,
+        credentials: credentialsPrivate,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore intentionally missing userid
+        parameters: parametersAuthorizePasswordless,
+      })
+    ).rejects.toThrow(
+      'Required argument userid is not provided through parameters'
+    );
+  });
+
   test('Throw when clientSecret is missing', async () => {
     const mockSlasClient = createMockSlasClient();
     const parametersAuthorizePasswordless = {
@@ -1035,6 +1056,34 @@ describe('getPasswordLessAccessToken is working', () => {
       })
     ).rejects.toThrow(
       'Required argument organizationId is not provided through clientConfig.parameters.organizationId'
+    );
+  });
+
+  test('Throw when clientSecret is missing', async () => {
+    const mockSlasClient = createMockSlasClient();
+    await expect(
+      slasHelper.getPasswordLessAccessToken({
+        slasClient: mockSlasClient,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore intentionally missing clientSecret
+        credentials: {},
+        parameters: {pwdlessLoginToken: '123456'},
+      })
+    ).rejects.toThrow('Required argument client secret is not provided');
+  });
+
+  test('Throw when pwdlessLoginToken is missing', async () => {
+    const mockSlasClient = createMockSlasClient();
+    await expect(
+      slasHelper.getPasswordLessAccessToken({
+        slasClient: mockSlasClient,
+        credentials: credentialsPrivate,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore intentionally missing pwdlessLoginToken
+        parameters: {},
+      })
+    ).rejects.toThrow(
+      'Required argument pwdlessLoginToken is not provided through parameters'
     );
   });
 });
@@ -1339,5 +1388,41 @@ describe('httpOnly session cookies', () => {
     // @ts-ignore
     delete global.btoa;
     jest.restoreAllMocks();
+  });
+
+  test('throws ResponseError when httpOnly raw response is not ok', async () => {
+    const mockGetAccessToken = jest.fn(() => ({
+      ok: false,
+      status: 401,
+      text: jest.fn().mockResolvedValue('Unauthorized'),
+      headers: {
+        get: jest.fn(() => null),
+      },
+    }));
+    const mockSlasClient = {
+      clientConfig: {
+        parameters: {
+          shortCode: 'short_code',
+          organizationId: 'organization_id',
+          clientId: 'client_id',
+          siteId: 'site_id',
+        },
+      },
+      getAccessToken: mockGetAccessToken,
+    } as unknown as ShopperLogin<{
+      shortCode: string;
+      organizationId: string;
+      clientId: string;
+      siteId: string;
+    }>;
+
+    await expect(
+      slasHelper.loginGuestUserPrivate({
+        slasClient: mockSlasClient,
+        parameters: {},
+        credentials: {clientSecret: 'slas_private_secret'},
+        enableHttpOnlySessionCookies: true,
+      })
+    ).rejects.toThrow(ResponseError);
   });
 });

--- a/src/static/helpers/slasHelper.test.ts
+++ b/src/static/helpers/slasHelper.test.ts
@@ -53,13 +53,63 @@ const parameters = {
 const url =
   'https://localhost:3000/callback?usid=048adcfb-aa93-4978-be9e-09cb569fdcb9&code=J2lHm0cgXmnXpwDhjhLoyLJBoUAlBfxDY-AhjqGMC-o';
 
+const createMockResponse = (
+  body: unknown,
+  setCookieHeaders?: string[]
+): Response =>
+  ({
+    ok: true,
+    status: 200,
+    text: jest.fn().mockResolvedValue(JSON.stringify(body)),
+    headers: {
+      get: jest.fn((name: string) =>
+        name === 'set-cookie' && setCookieHeaders
+          ? setCookieHeaders.join(', ')
+          : null
+      ),
+      getSetCookie: setCookieHeaders
+        ? jest.fn(() => setCookieHeaders)
+        : undefined,
+    },
+  } as unknown as Response);
+
+// Simulates the middleware stripping tokens from the body and setting them as httpOnly cookies
+const strippedTokenResponse = {
+  id_token: 'id_token',
+  expires_in: 0,
+  refresh_token_expires_in: 0,
+  token_type: 'Bearer',
+  usid: 'usid',
+  customer_id: 'customer_id',
+  enc_user_id: 'enc_user_id',
+};
+
+const mockSetCookieHeaders = [
+  'cc-at_site_id=access_token; Path=/; HttpOnly; Secure; SameSite=lax',
+  'cc-nx-g_site_id=refresh_token; Path=/; HttpOnly; Secure; SameSite=lax',
+  'idp_access_token_site_id=idp; Path=/; HttpOnly; Secure; SameSite=lax',
+];
+
 const authenticateCustomerMock = jest.fn(() => ({url}));
 
+// Returns parsed TokenResponse directly (enableHttpOnlySessionCookies=false)
 const getAccessTokenMock = jest.fn(() => expectedTokenResponse);
+
+// Simulates httpOnly mode: returns raw Response with tokens stripped
+// from body and placed in Set-Cookie headers (enableHttpOnlySessionCookies=true)
+const getAccessTokenMockHttpOnlySessionCookies = jest.fn(() =>
+  createMockResponse(strippedTokenResponse, mockSetCookieHeaders)
+);
+
 const logoutCustomerMock = jest.fn(() => expectedTokenResponse);
 const generateCodeChallengeMock = jest.fn(() => 'code_challenge');
 const authorizePasswordlessCustomerMock = jest.fn();
-const getPasswordLessAccessTokenMock = jest.fn();
+
+const getPasswordLessAccessTokenMock = jest.fn(() => expectedTokenResponse);
+
+const getPasswordLessAccessTokenMockHttpOnlySessionCookies = jest.fn(() =>
+  createMockResponse(strippedTokenResponse, mockSetCookieHeaders)
+);
 
 const createMockSlasClient = () =>
   ({
@@ -77,6 +127,32 @@ const createMockSlasClient = () =>
     generateCodeChallenge: generateCodeChallengeMock,
     authorizePasswordlessCustomer: authorizePasswordlessCustomerMock,
     getPasswordLessAccessToken: getPasswordLessAccessTokenMock,
+  } as unknown as ShopperLogin<{
+    shortCode: string;
+    organizationId: string;
+    clientId: string;
+    siteId: string;
+  }>);
+
+// Mock client for httpOnly session cookies tests.
+// Uses mocks that return raw Response with tokens in Set-Cookie headers.
+const createMockSlasClientHttpOnlySessionCookies = () =>
+  ({
+    clientConfig: {
+      parameters: {
+        shortCode: 'short_code',
+        organizationId: 'organization_id',
+        clientId: 'client_id',
+        siteId: 'site_id',
+      },
+    },
+    authenticateCustomer: authenticateCustomerMock,
+    getAccessToken: getAccessTokenMockHttpOnlySessionCookies,
+    logoutCustomer: logoutCustomerMock,
+    generateCodeChallenge: generateCodeChallengeMock,
+    authorizePasswordlessCustomer: authorizePasswordlessCustomerMock,
+    getPasswordLessAccessToken:
+      getPasswordLessAccessTokenMockHttpOnlySessionCookies,
   } as unknown as ShopperLogin<{
     shortCode: string;
     organizationId: string;
@@ -724,7 +800,7 @@ describe('Registered B2C user flow', () => {
       credentials,
       parameters: registeredUserFlowParams,
     });
-    expect(accessToken).toStrictEqual(expectedTokenResponse);
+    expect(accessToken).toBe(expectedTokenResponse);
   });
 });
 
@@ -968,7 +1044,7 @@ describe('getPasswordLessAccessToken is working', () => {
 });
 
 describe('Refresh Token', () => {
-  test('refreshes the token with slas public client', () => {
+  test('refreshes the token with slas public client', async () => {
     const expectedBody = {
       body: {
         client_id: 'client_id',
@@ -978,7 +1054,7 @@ describe('Refresh Token', () => {
         dnt: 'false',
       },
     };
-    const token = slasHelper.refreshAccessToken({
+    const token = await slasHelper.refreshAccessToken({
       slasClient: createMockSlasClient(),
       parameters,
     });
@@ -986,7 +1062,7 @@ describe('Refresh Token', () => {
     expect(token).toStrictEqual(expectedTokenResponse);
   });
 
-  test('refreshes the token with slas private client', () => {
+  test('refreshes the token with slas private client', async () => {
     const expectedReqOpts = {
       headers: {
         Authorization: `Basic ${stringToBase64(
@@ -1001,7 +1077,7 @@ describe('Refresh Token', () => {
         dnt: 'false',
       },
     };
-    const token = slasHelper.refreshAccessToken({
+    const token = await slasHelper.refreshAccessToken({
       slasClient: createMockSlasClient(),
       parameters,
       credentials: {
@@ -1032,5 +1108,240 @@ describe('Logout', () => {
     });
     expect(logoutCustomerMock).toBeCalledWith(expectedOptions);
     expect(token).toStrictEqual(expectedTokenResponse);
+  });
+});
+
+describe('httpOnly session cookies', () => {
+  test('loginGuestUser extracts tokens from Set-Cookie headers', async () => {
+    const mockSlasClient = createMockSlasClientHttpOnlySessionCookies();
+    const {shortCode, organizationId} = mockSlasClient.clientConfig.parameters;
+
+    nock(`https://${shortCode}.api.commercecloud.salesforce.com`)
+      .get(`/shopper/auth/v1/organizations/${organizationId}/oauth2/authorize`)
+      .query(true)
+      .reply(303, {response_body: 'response_body'}, {location: url});
+
+    const accessToken = await slasHelper.loginGuestUser({
+      slasClient: mockSlasClient,
+      parameters: {
+        redirectURI: 'redirect_uri',
+      },
+      enableHttpOnlySessionCookies: true,
+    });
+    expect(getAccessTokenMockHttpOnlySessionCookies).toBeCalledWith(
+      expect.any(Object),
+      true
+    );
+    expect(accessToken.access_token).toBe('access_token');
+    expect(accessToken.refresh_token).toBe('refresh_token');
+    expect(accessToken.idp_access_token).toBe('idp');
+  });
+
+  test('loginGuestUserPrivate extracts tokens from Set-Cookie headers', async () => {
+    const accessToken = await slasHelper.loginGuestUserPrivate({
+      slasClient: createMockSlasClientHttpOnlySessionCookies(),
+      parameters: {},
+      credentials: {clientSecret: 'slas_private_secret'},
+      enableHttpOnlySessionCookies: true,
+    });
+    expect(getAccessTokenMockHttpOnlySessionCookies).toBeCalledWith(
+      expect.any(Object),
+      true
+    );
+    expect(accessToken.access_token).toBe('access_token');
+    expect(accessToken.refresh_token).toBe('refresh_token');
+  });
+
+  test('refreshAccessToken extracts tokens from Set-Cookie headers', async () => {
+    const token = await slasHelper.refreshAccessToken({
+      slasClient: createMockSlasClientHttpOnlySessionCookies(),
+      parameters: {
+        refreshToken: 'refresh_token',
+        dnt: false,
+      },
+      enableHttpOnlySessionCookies: true,
+    });
+    expect(getAccessTokenMockHttpOnlySessionCookies).toBeCalledWith(
+      expect.any(Object),
+      true
+    );
+    expect(token.access_token).toBe('access_token');
+    expect(token.refresh_token).toBe('refresh_token');
+  });
+
+  test('refreshAccessToken with private client extracts tokens from Set-Cookie headers', async () => {
+    const token = await slasHelper.refreshAccessToken({
+      slasClient: createMockSlasClientHttpOnlySessionCookies(),
+      parameters: {
+        refreshToken: 'refresh_token',
+        dnt: false,
+      },
+      credentials: {clientSecret: 'slas_private_secret'},
+      enableHttpOnlySessionCookies: true,
+    });
+    expect(getAccessTokenMockHttpOnlySessionCookies).toBeCalledWith(
+      expect.any(Object),
+      true
+    );
+    expect(token.access_token).toBe('access_token');
+    expect(token.refresh_token).toBe('refresh_token');
+  });
+
+  test('loginIDPUser with private client extracts tokens from Set-Cookie headers', async () => {
+    const accessToken = await slasHelper.loginIDPUser({
+      slasClient: createMockSlasClientHttpOnlySessionCookies(),
+      credentials: {clientSecret: credentialsPrivate.clientSecret},
+      parameters: {
+        redirectURI: 'redirect_uri',
+        code: 'J2lHm0cgXmnXpwDhjhLoyLJBoUAlBfxDY-AhjqGMC-o',
+        usid: '048adcfb-aa93-4978-be9e-09cb569fdcb9',
+        dnt: false,
+      },
+      enableHttpOnlySessionCookies: true,
+    });
+    expect(getAccessTokenMockHttpOnlySessionCookies).toBeCalledWith(
+      expect.any(Object),
+      true
+    );
+    expect(accessToken.access_token).toBe('access_token');
+    expect(accessToken.refresh_token).toBe('refresh_token');
+    expect(accessToken.idp_access_token).toBe('idp');
+  });
+
+  test('loginIDPUser with public client extracts tokens from Set-Cookie headers', async () => {
+    const accessToken = await slasHelper.loginIDPUser({
+      slasClient: createMockSlasClientHttpOnlySessionCookies(),
+      credentials: {codeVerifier: 'code_verifier'},
+      parameters: {
+        redirectURI: 'redirect_uri',
+        code: 'J2lHm0cgXmnXpwDhjhLoyLJBoUAlBfxDY-AhjqGMC-o',
+        usid: '048adcfb-aa93-4978-be9e-09cb569fdcb9',
+        dnt: false,
+      },
+      enableHttpOnlySessionCookies: true,
+    });
+    expect(getAccessTokenMockHttpOnlySessionCookies).toBeCalledWith(
+      expect.any(Object),
+      true
+    );
+    expect(accessToken.access_token).toBe('access_token');
+    expect(accessToken.refresh_token).toBe('refresh_token');
+  });
+
+  test('loginRegisteredUserB2C with public client extracts tokens from Set-Cookie headers', async () => {
+    const mockSlasClient = createMockSlasClientHttpOnlySessionCookies();
+    const {shortCode, organizationId} = mockSlasClient.clientConfig.parameters;
+
+    nock(`https://${shortCode}.api.commercecloud.salesforce.com`)
+      .post(`/shopper/auth/v1/organizations/${organizationId}/oauth2/login`)
+      .reply(303, {response_body: 'response_body'}, {location: url});
+
+    const accessToken = await slasHelper.loginRegisteredUserB2C({
+      slasClient: mockSlasClient,
+      credentials,
+      parameters: {
+        redirectURI: 'redirect_uri',
+        dnt: false,
+      },
+      enableHttpOnlySessionCookies: true,
+    });
+    expect(getAccessTokenMockHttpOnlySessionCookies).toBeCalledWith(
+      expect.any(Object),
+      true
+    );
+    expect(accessToken.access_token).toBe('access_token');
+    expect(accessToken.refresh_token).toBe('refresh_token');
+  });
+
+  test('loginRegisteredUserB2C with private client extracts tokens from Set-Cookie headers', async () => {
+    const mockSlasClient = createMockSlasClientHttpOnlySessionCookies();
+    const {shortCode, organizationId} = mockSlasClient.clientConfig.parameters;
+
+    nock(`https://${shortCode}.api.commercecloud.salesforce.com`)
+      .post(`/shopper/auth/v1/organizations/${organizationId}/oauth2/login`)
+      .reply(303, {response_body: 'response_body'}, {location: url});
+
+    const accessToken = await slasHelper.loginRegisteredUserB2C({
+      slasClient: mockSlasClient,
+      credentials: credentialsPrivate,
+      parameters: {
+        redirectURI: 'redirect_uri',
+        dnt: false,
+      },
+      enableHttpOnlySessionCookies: true,
+    });
+    expect(getAccessTokenMockHttpOnlySessionCookies).toBeCalledWith(
+      expect.any(Object),
+      true
+    );
+    expect(accessToken.access_token).toBe('access_token');
+    expect(accessToken.refresh_token).toBe('refresh_token');
+  });
+
+  test('getPasswordLessAccessToken extracts tokens from Set-Cookie headers', async () => {
+    const token = await slasHelper.getPasswordLessAccessToken({
+      slasClient: createMockSlasClientHttpOnlySessionCookies(),
+      credentials: {clientSecret: 'slas_private_secret'},
+      parameters: {
+        pwdlessLoginToken: 'pwdless_token',
+      },
+      enableHttpOnlySessionCookies: true,
+    });
+    expect(getPasswordLessAccessTokenMockHttpOnlySessionCookies).toBeCalledWith(
+      expect.any(Object),
+      true
+    );
+    expect(token.access_token).toBe('access_token');
+    expect(token.refresh_token).toBe('refresh_token');
+  });
+
+  test('does not extract tokens from Set-Cookie headers on browser (isBrowser=true)', async () => {
+    // Re-import slasHelper with isBrowser mocked to true
+    jest.resetModules();
+    // Provide btoa for the browser mock since stringToBase64 uses it when isBrowser=true
+    global.btoa = (str: string) => Buffer.from(str).toString('base64');
+    jest.doMock('./environment', () => ({isBrowser: true}));
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+    const browserSlasHelper = require('./slasHelper') as typeof slasHelper;
+
+    // Mock client that returns stripped body + Set-Cookie headers
+    const mockGetAccessToken = jest.fn(() =>
+      createMockResponse(strippedTokenResponse, mockSetCookieHeaders)
+    );
+    const mockSlasClient = {
+      clientConfig: {
+        parameters: {
+          shortCode: 'short_code',
+          organizationId: 'organization_id',
+          clientId: 'client_id',
+          siteId: 'site_id',
+        },
+      },
+      getAccessToken: mockGetAccessToken,
+    } as unknown as ShopperLogin<{
+      shortCode: string;
+      organizationId: string;
+      clientId: string;
+      siteId: string;
+    }>;
+
+    const accessToken = await browserSlasHelper.loginGuestUserPrivate({
+      slasClient: mockSlasClient,
+      parameters: {},
+      credentials: {clientSecret: 'slas_private_secret'},
+      enableHttpOnlySessionCookies: true,
+    });
+
+    // On browser: tokens should NOT be extracted from Set-Cookie headers
+    // The stripped body is returned as-is (browser relies on httpOnly cookies)
+    expect(accessToken.access_token).toBeUndefined();
+    expect(accessToken.refresh_token).toBeUndefined();
+    expect(accessToken.customer_id).toBe('customer_id');
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    delete global.btoa;
+    jest.restoreAllMocks();
   });
 });

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -23,6 +23,89 @@ import {
   CustomRequestBody,
 } from './types';
 
+/**
+ * Parses a Set-Cookie header value and returns the cookie name and value.
+ */
+const parseSetCookieNameValue = (
+  cookie: string
+): {name: string; value: string} | null => {
+  const [nameValue] = cookie.split(';');
+  const eqIndex = nameValue.indexOf('=');
+  if (eqIndex === -1) return null;
+  return {
+    name: nameValue.substring(0, eqIndex).trim(),
+    value: nameValue.substring(eqIndex + 1).trim(),
+  };
+};
+
+/**
+ * Extracts SLAS tokens from Set-Cookie response headers.
+ * Maps httpOnly cookie names back to TokenResponse fields.
+ * @param setCookieHeaders - Array of Set-Cookie header strings
+ * @param siteId - The site ID used as the cookie suffix
+ * @returns Partial TokenResponse with extracted token fields
+ */
+const extractTokensFromSetCookieHeader = (
+  setCookieHeaders: string[],
+  siteId: string
+): Partial<TokenResponse> => {
+  const tokens: Partial<TokenResponse> = {};
+  setCookieHeaders.forEach(cookie => {
+    const parsed = parseSetCookieNameValue(cookie);
+    if (!parsed) return;
+
+    const {name, value} = parsed;
+    if (name === `cc-at_${siteId}`) {
+      tokens.access_token = value;
+    } else if (name === `cc-nx_${siteId}` || name === `cc-nx-g_${siteId}`) {
+      tokens.refresh_token = value;
+    } else if (name === `idp_access_token_${siteId}`) {
+      tokens.idp_access_token = value;
+    }
+  });
+  return tokens;
+};
+
+/**
+ * Parses a SLAS token response. When enableHttpOnlySessionCookies is true
+ * and running on the server, tokens are extracted from Set-Cookie headers
+ * and merged back into the response body (since the middleware strips them).
+ * On the browser, the stripped body is returned as-is (tokens are handled
+ * via httpOnly cookies automatically).
+ * @param response - The raw Response from a SLAS token endpoint
+ * @param siteId - The site ID used as the cookie suffix
+ * @param enableHttpOnlySessionCookies - Whether httpOnly session cookies mode is enabled
+ * @returns A complete TokenResponse
+ */
+const parseTokenResponseWithHttpOnlySessionCookies = async (
+  response: Response,
+  siteId: string,
+  enableHttpOnlySessionCookies = false
+): Promise<TokenResponse> => {
+  const text = await response.text();
+  const body = (text ? JSON.parse(text) : {}) as TokenResponse;
+
+  if (!enableHttpOnlySessionCookies || isBrowser) {
+    return body;
+  }
+
+  // Server-side + httpOnly enabled: restore tokens from Set-Cookie headers
+  // getSetCookie() is the standard API but may not exist in older runtimes
+  const {getSetCookie} = response.headers as unknown as {
+    getSetCookie?: () => string[];
+  };
+  const setCookieHeaders: string[] =
+    getSetCookie?.call(response.headers) ??
+    response.headers.get('set-cookie')?.split(/,(?=\s*\w+=)/) ??
+    [];
+
+  const cookieTokens = extractTokensFromSetCookieHeader(
+    setCookieHeaders,
+    siteId
+  );
+  return {...body, ...cookieTokens};
+};
+
 export const stringToBase64 = isBrowser
   ? btoa
   : (unencoded: string): string => Buffer.from(unencoded).toString('base64');
@@ -282,8 +365,14 @@ export async function loginIDPUser(options: {
     usid?: string;
     dnt?: boolean;
   };
+  enableHttpOnlySessionCookies?: boolean;
 }): Promise<TokenResponse> {
-  const {slasClient, credentials, parameters} = options;
+  const {
+    slasClient,
+    credentials,
+    parameters,
+    enableHttpOnlySessionCookies = false,
+  } = options;
   const privateClient = !!credentials.clientSecret;
 
   const tokenBody = {
@@ -312,9 +401,25 @@ export async function loginIDPUser(options: {
       },
       body: tokenBody,
     };
+    if (enableHttpOnlySessionCookies) {
+      const response = await slasClient.getAccessToken(optionsToken, true);
+      return parseTokenResponseWithHttpOnlySessionCookies(
+        response,
+        slasClient.clientConfig.parameters.siteId,
+        enableHttpOnlySessionCookies
+      );
+    }
     return slasClient.getAccessToken(optionsToken);
   }
   // default is to use slas public client
+  if (enableHttpOnlySessionCookies) {
+    const response = await slasClient.getAccessToken({body: tokenBody}, true);
+    return parseTokenResponseWithHttpOnlySessionCookies(
+      response,
+      slasClient.clientConfig.parameters.siteId,
+      enableHttpOnlySessionCookies
+    );
+  }
   return slasClient.getAccessToken({body: tokenBody});
 }
 
@@ -344,8 +449,14 @@ export async function loginGuestUserPrivate(options: {
   credentials: {
     clientSecret: string;
   };
+  enableHttpOnlySessionCookies?: boolean;
 }): Promise<TokenResponse> {
-  const {slasClient, parameters, credentials} = options;
+  const {
+    slasClient,
+    parameters,
+    credentials,
+    enableHttpOnlySessionCookies = false,
+  } = options;
   if (!slasClient.clientConfig.parameters.siteId) {
     throw new Error(
       'Required argument channel_id is not provided through clientConfig.parameters.siteId'
@@ -368,6 +479,14 @@ export async function loginGuestUserPrivate(options: {
     },
   };
 
+  if (enableHttpOnlySessionCookies) {
+    const response = await slasClient.getAccessToken(opts, true);
+    return parseTokenResponseWithHttpOnlySessionCookies(
+      response,
+      slasClient.clientConfig.parameters.siteId,
+      enableHttpOnlySessionCookies
+    );
+  }
   return slasClient.getAccessToken(opts);
 }
 
@@ -393,8 +512,13 @@ export async function loginGuestUser(options: {
     usid?: string;
     dnt?: boolean;
   } & CustomQueryParameters;
+  enableHttpOnlySessionCookies?: boolean;
 }): Promise<TokenResponse> {
-  const {slasClient, parameters} = options;
+  const {
+    slasClient,
+    parameters,
+    enableHttpOnlySessionCookies = false,
+  } = options;
   const codeVerifier = createCodeVerifier();
 
   const {dnt, redirectURI, usid, ...restOfParams} = parameters;
@@ -422,6 +546,14 @@ export async function loginGuestUser(options: {
     ...(dnt !== undefined && {dnt: dnt.toString()}),
   };
 
+  if (enableHttpOnlySessionCookies) {
+    const response = await slasClient.getAccessToken({body: tokenBody}, true);
+    return parseTokenResponseWithHttpOnlySessionCookies(
+      response,
+      slasClient.clientConfig.parameters.siteId,
+      enableHttpOnlySessionCookies
+    );
+  }
   return slasClient.getAccessToken({body: tokenBody});
 }
 
@@ -459,8 +591,15 @@ export async function loginRegisteredUserB2C(options: {
     dnt?: boolean;
   };
   body?: CustomRequestBody;
+  enableHttpOnlySessionCookies?: boolean;
 }): Promise<TokenResponse> {
-  const {slasClient, credentials, parameters, body} = options;
+  const {
+    slasClient,
+    credentials,
+    parameters,
+    body,
+    enableHttpOnlySessionCookies = false,
+  } = options;
   const codeVerifier = createCodeVerifier();
   const codeChallenge = await generateCodeChallenge(codeVerifier);
 
@@ -530,9 +669,28 @@ export async function loginRegisteredUserB2C(options: {
       },
       body: tokenBody,
     };
+    if (enableHttpOnlySessionCookies) {
+      const tokenResponse = await slasClient.getAccessToken(optionsToken, true);
+      return parseTokenResponseWithHttpOnlySessionCookies(
+        tokenResponse,
+        slasClient.clientConfig.parameters.siteId,
+        enableHttpOnlySessionCookies
+      );
+    }
     return slasClient.getAccessToken(optionsToken);
   }
   // default is to use slas public client
+  if (enableHttpOnlySessionCookies) {
+    const tokenResponse = await slasClient.getAccessToken(
+      {body: tokenBody},
+      true
+    );
+    return parseTokenResponseWithHttpOnlySessionCookies(
+      tokenResponse,
+      slasClient.clientConfig.parameters.siteId,
+      enableHttpOnlySessionCookies
+    );
+  }
   return slasClient.getAccessToken({body: tokenBody});
 }
 
@@ -661,8 +819,14 @@ export async function getPasswordLessAccessToken(options: {
     pwdlessLoginToken: string;
     dnt?: string;
   };
+  enableHttpOnlySessionCookies?: boolean;
 }): Promise<TokenResponse> {
-  const {slasClient, credentials, parameters} = options;
+  const {
+    slasClient,
+    credentials,
+    parameters,
+    enableHttpOnlySessionCookies = false,
+  } = options;
   if (!credentials.clientSecret) {
     throw new Error('Required argument client secret is not provided');
   }
@@ -688,6 +852,25 @@ export async function getPasswordLessAccessToken(options: {
     code_verifier: codeVerifier,
     ...(parameters.dnt && {dnt: parameters.dnt}),
   };
+  if (enableHttpOnlySessionCookies) {
+    const response = await slasClient.getPasswordLessAccessToken(
+      {
+        headers: {
+          Authorization: authHeaderIdSecret,
+        },
+        parameters: {
+          organizationId: slasClient.clientConfig.parameters.organizationId,
+        },
+        body: tokenBody,
+      },
+      true
+    );
+    return parseTokenResponseWithHttpOnlySessionCookies(
+      response,
+      slasClient.clientConfig.parameters.siteId,
+      enableHttpOnlySessionCookies
+    );
+  }
   return slasClient.getPasswordLessAccessToken({
     headers: {
       Authorization: authHeaderIdSecret,
@@ -710,7 +893,7 @@ export async function getPasswordLessAccessToken(options: {
  * @param options.credentials.clientSecret? - secret associated with client ID
  * @returns TokenResponse
  */
-export function refreshAccessToken(options: {
+export async function refreshAccessToken(options: {
   slasClient: ShopperLogin<{
     shortCode: string;
     organizationId: string;
@@ -722,8 +905,14 @@ export function refreshAccessToken(options: {
     dnt?: boolean;
   };
   credentials?: {clientSecret?: string};
+  enableHttpOnlySessionCookies?: boolean;
 }): Promise<TokenResponse> {
-  const {slasClient, parameters, credentials} = options;
+  const {
+    slasClient,
+    parameters,
+    credentials,
+    enableHttpOnlySessionCookies = false,
+  } = options;
   const body = {
     grant_type: 'refresh_token' as const,
     refresh_token: parameters.refreshToken,
@@ -742,9 +931,25 @@ export function refreshAccessToken(options: {
       },
       body,
     };
+    if (enableHttpOnlySessionCookies) {
+      const response = await slasClient.getAccessToken(opts, true);
+      return parseTokenResponseWithHttpOnlySessionCookies(
+        response,
+        slasClient.clientConfig.parameters.siteId,
+        enableHttpOnlySessionCookies
+      );
+    }
     return slasClient.getAccessToken(opts);
   }
 
+  if (enableHttpOnlySessionCookies) {
+    const response = await slasClient.getAccessToken({body}, true);
+    return parseTokenResponseWithHttpOnlySessionCookies(
+      response,
+      slasClient.clientConfig.parameters.siteId,
+      enableHttpOnlySessionCookies
+    );
+  }
   return slasClient.getAccessToken({body});
 }
 

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -111,7 +111,12 @@ const parseTokenResponseHttpOnly = async (
  * HttpOnly session cookie response.
  */
 const getAccessTokenHttpOnly = async (
-  slasClient: ShopperLogin<{shortCode: string; organizationId: string; clientId: string; siteId: string}>,
+  slasClient: ShopperLogin<{
+    shortCode: string;
+    organizationId: string;
+    clientId: string;
+    siteId: string;
+  }>,
   opts: Parameters<typeof slasClient.getAccessToken>[0]
 ): Promise<TokenResponse> => {
   const response = await slasClient.getAccessToken(opts, true);
@@ -624,7 +629,10 @@ export async function loginRegisteredUserB2C(options: {
     },
   };
 
-  const response = await slasClientCopy.authenticateCustomer(authCustomerOpts, true);
+  const response = await slasClientCopy.authenticateCustomer(
+    authCustomerOpts,
+    true
+  );
   const redirectUrlString = response.headers?.get('location') || response.url;
   const redirectUrl = new URL(redirectUrlString);
   const searchParams = Object.fromEntries(redirectUrl.searchParams.entries());

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -90,14 +90,11 @@ const parseTokenResponseWithHttpOnlySessionCookies = async (
   }
 
   // Server-side + httpOnly enabled: restore tokens from Set-Cookie headers
-  // getSetCookie() is the standard API but may not exist in older runtimes
-  const {getSetCookie} = response.headers as unknown as {
-    getSetCookie?: () => string[];
+  // node-fetch's Headers has a raw() method that returns individual Set-Cookie headers as an array
+  const headers = response.headers as Headers & {
+    raw?: () => Record<string, string[]>;
   };
-  const setCookieHeaders: string[] =
-    getSetCookie?.call(response.headers) ??
-    response.headers.get('set-cookie')?.split(/,(?=\s*\w+=)/) ??
-    [];
+  const setCookieHeaders: string[] = headers.raw?.()?.['set-cookie'] ?? [];
 
   const cookieTokens = extractTokensFromSetCookieHeader(
     setCookieHeaders,

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -76,10 +76,13 @@ const extractTokensFromSetCookieHeader = (
  * @param siteId - The site ID used as the cookie suffix
  * @returns A complete TokenResponse
  */
-const parseTokenResponseWithHttpOnlySessionCookies = async (
+const parseTokenResponseHttpOnly = async (
   response: Response,
   siteId: string
 ): Promise<TokenResponse> => {
+  if (!response.ok) {
+    throw new ResponseError(response);
+  }
   const text = await response.text();
   const body = (text ? JSON.parse(text) : {}) as TokenResponse;
 
@@ -88,17 +91,34 @@ const parseTokenResponseWithHttpOnlySessionCookies = async (
   }
 
   // Server-side + httpOnly enabled: restore tokens from Set-Cookie headers
-  // node-fetch's Headers has a raw() method that returns individual Set-Cookie headers as an array
+  // Native fetch uses getSetCookie(); node-fetch polyfill uses raw()['set-cookie']
   const headers = response.headers as Headers & {
+    getSetCookie?: () => string[];
     raw?: () => Record<string, string[]>;
   };
-  const setCookieHeaders: string[] = headers.raw?.()?.['set-cookie'] ?? [];
+  const setCookieHeaders: string[] =
+    headers.getSetCookie?.() ?? headers.raw?.()?.['set-cookie'] ?? [];
 
   const cookieTokens = extractTokensFromSetCookieHeader(
     setCookieHeaders,
     siteId
   );
   return {...body, ...cookieTokens};
+};
+
+/**
+ * Calls slasClient.getAccessToken with rawResponse=true and parses the
+ * HttpOnly session cookie response.
+ */
+const getAccessTokenHttpOnly = async (
+  slasClient: ShopperLogin<{shortCode: string; organizationId: string; clientId: string; siteId: string}>,
+  opts: Parameters<typeof slasClient.getAccessToken>[0]
+): Promise<TokenResponse> => {
+  const response = await slasClient.getAccessToken(opts, true);
+  return parseTokenResponseHttpOnly(
+    response,
+    slasClient.clientConfig.parameters.siteId
+  );
 };
 
 export const stringToBase64 = isBrowser
@@ -384,36 +404,19 @@ export async function loginIDPUser(options: {
     ...(parameters.dnt !== undefined && {dnt: parameters.dnt.toString()}),
     ...(parameters.usid && {usid: parameters.usid}),
   };
-  // Using slas private client
+  const opts: Parameters<typeof slasClient.getAccessToken>[0] = {body: tokenBody};
   if (credentials.clientSecret) {
-    const authHeaderIdSecret = `Basic ${stringToBase64(
-      `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
-    )}`;
-
-    const optionsToken = {
-      headers: {
-        Authorization: authHeaderIdSecret,
-      },
-      body: tokenBody,
+    opts.headers = {
+      Authorization: `Basic ${stringToBase64(
+        `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
+      )}`,
     };
-    if (enableHttpOnlySessionCookies) {
-      const response = await slasClient.getAccessToken(optionsToken, true);
-      return parseTokenResponseWithHttpOnlySessionCookies(
-        response,
-        slasClient.clientConfig.parameters.siteId
-      );
-    }
-    return slasClient.getAccessToken(optionsToken);
   }
-  // default is to use slas public client
+
   if (enableHttpOnlySessionCookies) {
-    const response = await slasClient.getAccessToken({body: tokenBody}, true);
-    return parseTokenResponseWithHttpOnlySessionCookies(
-      response,
-      slasClient.clientConfig.parameters.siteId
-    );
+    return getAccessTokenHttpOnly(slasClient, opts);
   }
-  return slasClient.getAccessToken({body: tokenBody});
+  return slasClient.getAccessToken(opts);
 }
 
 /**
@@ -473,11 +476,7 @@ export async function loginGuestUserPrivate(options: {
   };
 
   if (enableHttpOnlySessionCookies) {
-    const response = await slasClient.getAccessToken(opts, true);
-    return parseTokenResponseWithHttpOnlySessionCookies(
-      response,
-      slasClient.clientConfig.parameters.siteId
-    );
+    return getAccessTokenHttpOnly(slasClient, opts);
   }
   return slasClient.getAccessToken(opts);
 }
@@ -539,11 +538,7 @@ export async function loginGuestUser(options: {
   };
 
   if (enableHttpOnlySessionCookies) {
-    const response = await slasClient.getAccessToken({body: tokenBody}, true);
-    return parseTokenResponseWithHttpOnlySessionCookies(
-      response,
-      slasClient.clientConfig.parameters.siteId
-    );
+    return getAccessTokenHttpOnly(slasClient, {body: tokenBody});
   }
   return slasClient.getAccessToken({body: tokenBody});
 }
@@ -610,7 +605,7 @@ export async function loginRegisteredUserB2C(options: {
     `${credentials.username}:${credentials.password}`
   )}`;
   const {dnt, usid, redirectURI} = parameters;
-  const opts = {
+  const authCustomerOpts = {
     headers: {
       Authorization: authorization,
     },
@@ -627,7 +622,7 @@ export async function loginRegisteredUserB2C(options: {
     },
   };
 
-  const response = await slasClientCopy.authenticateCustomer(opts, true);
+  const response = await slasClientCopy.authenticateCustomer(authCustomerOpts, true);
   const redirectUrlString = response.headers?.get('location') || response.url;
   const redirectUrl = new URL(redirectUrlString);
   const searchParams = Object.fromEntries(redirectUrl.searchParams.entries());
@@ -648,39 +643,19 @@ export async function loginRegisteredUserB2C(options: {
     usid: authResponse.usid,
     ...(dnt !== undefined && {dnt: dnt.toString()}),
   };
-  // using slas private client
+  const opts: Parameters<typeof slasClient.getAccessToken>[0] = {body: tokenBody};
   if (credentials.clientSecret) {
-    const authHeaderIdSecret = `Basic ${stringToBase64(
-      `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
-    )}`;
-
-    const optionsToken = {
-      headers: {
-        Authorization: authHeaderIdSecret,
-      },
-      body: tokenBody,
+    opts.headers = {
+      Authorization: `Basic ${stringToBase64(
+        `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
+      )}`,
     };
-    if (enableHttpOnlySessionCookies) {
-      const tokenResponse = await slasClient.getAccessToken(optionsToken, true);
-      return parseTokenResponseWithHttpOnlySessionCookies(
-        tokenResponse,
-        slasClient.clientConfig.parameters.siteId
-      );
-    }
-    return slasClient.getAccessToken(optionsToken);
   }
-  // default is to use slas public client
+
   if (enableHttpOnlySessionCookies) {
-    const tokenResponse = await slasClient.getAccessToken(
-      {body: tokenBody},
-      true
-    );
-    return parseTokenResponseWithHttpOnlySessionCookies(
-      tokenResponse,
-      slasClient.clientConfig.parameters.siteId
-    );
+    return getAccessTokenHttpOnly(slasClient, opts);
   }
-  return slasClient.getAccessToken({body: tokenBody});
+  return slasClient.getAccessToken(opts);
 }
 
 /** Function to send passwordless login token
@@ -841,25 +816,7 @@ export async function getPasswordLessAccessToken(options: {
     code_verifier: codeVerifier,
     ...(parameters.dnt && {dnt: parameters.dnt}),
   };
-  if (enableHttpOnlySessionCookies) {
-    const response = await slasClient.getPasswordLessAccessToken(
-      {
-        headers: {
-          Authorization: authHeaderIdSecret,
-        },
-        parameters: {
-          organizationId: slasClient.clientConfig.parameters.organizationId,
-        },
-        body: tokenBody,
-      },
-      true
-    );
-    return parseTokenResponseWithHttpOnlySessionCookies(
-      response,
-      slasClient.clientConfig.parameters.siteId
-    );
-  }
-  return slasClient.getPasswordLessAccessToken({
+  const requestOptions = {
     headers: {
       Authorization: authHeaderIdSecret,
     },
@@ -867,7 +824,18 @@ export async function getPasswordLessAccessToken(options: {
       organizationId: slasClient.clientConfig.parameters.organizationId,
     },
     body: tokenBody,
-  });
+  };
+  if (enableHttpOnlySessionCookies) {
+    const response = await slasClient.getPasswordLessAccessToken(
+      requestOptions,
+      true
+    );
+    return parseTokenResponseHttpOnly(
+      response,
+      slasClient.clientConfig.parameters.siteId
+    );
+  }
+  return slasClient.getPasswordLessAccessToken(requestOptions);
 }
 
 /**
@@ -909,34 +877,19 @@ export async function refreshAccessToken(options: {
     ...(parameters.dnt !== undefined && {dnt: parameters.dnt.toString()}),
   };
 
-  if (credentials && credentials.clientSecret) {
-    const authorization = `Basic ${stringToBase64(
-      `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
-    )}`;
-    const opts = {
-      headers: {
-        Authorization: authorization,
-      },
-      body,
+  const opts: Parameters<typeof slasClient.getAccessToken>[0] = {body};
+  if (credentials?.clientSecret) {
+    opts.headers = {
+      Authorization: `Basic ${stringToBase64(
+        `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
+      )}`,
     };
-    if (enableHttpOnlySessionCookies) {
-      const response = await slasClient.getAccessToken(opts, true);
-      return parseTokenResponseWithHttpOnlySessionCookies(
-        response,
-        slasClient.clientConfig.parameters.siteId
-      );
-    }
-    return slasClient.getAccessToken(opts);
   }
 
   if (enableHttpOnlySessionCookies) {
-    const response = await slasClient.getAccessToken({body}, true);
-    return parseTokenResponseWithHttpOnlySessionCookies(
-      response,
-      slasClient.clientConfig.parameters.siteId
-    );
+    return getAccessTokenHttpOnly(slasClient, opts);
   }
-  return slasClient.getAccessToken({body});
+  return slasClient.getAccessToken(opts);
 }
 
 /**

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -74,18 +74,16 @@ const extractTokensFromSetCookieHeader = (
  * via httpOnly cookies automatically).
  * @param response - The raw Response from a SLAS token endpoint
  * @param siteId - The site ID used as the cookie suffix
- * @param enableHttpOnlySessionCookies - Whether httpOnly session cookies mode is enabled
  * @returns A complete TokenResponse
  */
 const parseTokenResponseWithHttpOnlySessionCookies = async (
   response: Response,
-  siteId: string,
-  enableHttpOnlySessionCookies = false
+  siteId: string
 ): Promise<TokenResponse> => {
   const text = await response.text();
   const body = (text ? JSON.parse(text) : {}) as TokenResponse;
 
-  if (!enableHttpOnlySessionCookies || isBrowser) {
+  if (isBrowser) {
     return body;
   }
 
@@ -402,8 +400,7 @@ export async function loginIDPUser(options: {
       const response = await slasClient.getAccessToken(optionsToken, true);
       return parseTokenResponseWithHttpOnlySessionCookies(
         response,
-        slasClient.clientConfig.parameters.siteId,
-        enableHttpOnlySessionCookies
+        slasClient.clientConfig.parameters.siteId
       );
     }
     return slasClient.getAccessToken(optionsToken);
@@ -413,8 +410,7 @@ export async function loginIDPUser(options: {
     const response = await slasClient.getAccessToken({body: tokenBody}, true);
     return parseTokenResponseWithHttpOnlySessionCookies(
       response,
-      slasClient.clientConfig.parameters.siteId,
-      enableHttpOnlySessionCookies
+      slasClient.clientConfig.parameters.siteId
     );
   }
   return slasClient.getAccessToken({body: tokenBody});
@@ -480,8 +476,7 @@ export async function loginGuestUserPrivate(options: {
     const response = await slasClient.getAccessToken(opts, true);
     return parseTokenResponseWithHttpOnlySessionCookies(
       response,
-      slasClient.clientConfig.parameters.siteId,
-      enableHttpOnlySessionCookies
+      slasClient.clientConfig.parameters.siteId
     );
   }
   return slasClient.getAccessToken(opts);
@@ -547,8 +542,7 @@ export async function loginGuestUser(options: {
     const response = await slasClient.getAccessToken({body: tokenBody}, true);
     return parseTokenResponseWithHttpOnlySessionCookies(
       response,
-      slasClient.clientConfig.parameters.siteId,
-      enableHttpOnlySessionCookies
+      slasClient.clientConfig.parameters.siteId
     );
   }
   return slasClient.getAccessToken({body: tokenBody});
@@ -670,8 +664,7 @@ export async function loginRegisteredUserB2C(options: {
       const tokenResponse = await slasClient.getAccessToken(optionsToken, true);
       return parseTokenResponseWithHttpOnlySessionCookies(
         tokenResponse,
-        slasClient.clientConfig.parameters.siteId,
-        enableHttpOnlySessionCookies
+        slasClient.clientConfig.parameters.siteId
       );
     }
     return slasClient.getAccessToken(optionsToken);
@@ -684,8 +677,7 @@ export async function loginRegisteredUserB2C(options: {
     );
     return parseTokenResponseWithHttpOnlySessionCookies(
       tokenResponse,
-      slasClient.clientConfig.parameters.siteId,
-      enableHttpOnlySessionCookies
+      slasClient.clientConfig.parameters.siteId
     );
   }
   return slasClient.getAccessToken({body: tokenBody});
@@ -864,8 +856,7 @@ export async function getPasswordLessAccessToken(options: {
     );
     return parseTokenResponseWithHttpOnlySessionCookies(
       response,
-      slasClient.clientConfig.parameters.siteId,
-      enableHttpOnlySessionCookies
+      slasClient.clientConfig.parameters.siteId
     );
   }
   return slasClient.getPasswordLessAccessToken({
@@ -932,8 +923,7 @@ export async function refreshAccessToken(options: {
       const response = await slasClient.getAccessToken(opts, true);
       return parseTokenResponseWithHttpOnlySessionCookies(
         response,
-        slasClient.clientConfig.parameters.siteId,
-        enableHttpOnlySessionCookies
+        slasClient.clientConfig.parameters.siteId
       );
     }
     return slasClient.getAccessToken(opts);
@@ -943,8 +933,7 @@ export async function refreshAccessToken(options: {
     const response = await slasClient.getAccessToken({body}, true);
     return parseTokenResponseWithHttpOnlySessionCookies(
       response,
-      slasClient.clientConfig.parameters.siteId,
-      enableHttpOnlySessionCookies
+      slasClient.clientConfig.parameters.siteId
     );
   }
   return slasClient.getAccessToken({body});

--- a/src/static/helpers/slasHelper.ts
+++ b/src/static/helpers/slasHelper.ts
@@ -404,14 +404,16 @@ export async function loginIDPUser(options: {
     ...(parameters.dnt !== undefined && {dnt: parameters.dnt.toString()}),
     ...(parameters.usid && {usid: parameters.usid}),
   };
-  const opts: Parameters<typeof slasClient.getAccessToken>[0] = {body: tokenBody};
-  if (credentials.clientSecret) {
-    opts.headers = {
-      Authorization: `Basic ${stringToBase64(
-        `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
-      )}`,
-    };
-  }
+  const opts = {
+    body: tokenBody,
+    ...(credentials.clientSecret && {
+      headers: {
+        Authorization: `Basic ${stringToBase64(
+          `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
+        )}`,
+      },
+    }),
+  };
 
   if (enableHttpOnlySessionCookies) {
     return getAccessTokenHttpOnly(slasClient, opts);
@@ -643,14 +645,16 @@ export async function loginRegisteredUserB2C(options: {
     usid: authResponse.usid,
     ...(dnt !== undefined && {dnt: dnt.toString()}),
   };
-  const opts: Parameters<typeof slasClient.getAccessToken>[0] = {body: tokenBody};
-  if (credentials.clientSecret) {
-    opts.headers = {
-      Authorization: `Basic ${stringToBase64(
-        `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
-      )}`,
-    };
-  }
+  const opts = {
+    body: tokenBody,
+    ...(credentials.clientSecret && {
+      headers: {
+        Authorization: `Basic ${stringToBase64(
+          `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
+        )}`,
+      },
+    }),
+  };
 
   if (enableHttpOnlySessionCookies) {
     return getAccessTokenHttpOnly(slasClient, opts);
@@ -877,14 +881,16 @@ export async function refreshAccessToken(options: {
     ...(parameters.dnt !== undefined && {dnt: parameters.dnt.toString()}),
   };
 
-  const opts: Parameters<typeof slasClient.getAccessToken>[0] = {body};
-  if (credentials?.clientSecret) {
-    opts.headers = {
-      Authorization: `Basic ${stringToBase64(
-        `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
-      )}`,
-    };
-  }
+  const opts = {
+    body,
+    ...(credentials?.clientSecret && {
+      headers: {
+        Authorization: `Basic ${stringToBase64(
+          `${slasClient.clientConfig.parameters.clientId}:${credentials.clientSecret}`
+        )}`,
+      },
+    }),
+  };
 
   if (enableHttpOnlySessionCookies) {
     return getAccessTokenHttpOnly(slasClient, opts);


### PR DESCRIPTION
When enableHttpOnlySessionCookies is true, the PWA-KIT middleware strips tokens from the SLAS response body and sets them as httpOnly cookies. During SSR, the SDK needs to extract these tokens from Set-Cookie headers and merge them back into the TokenResponse.

Changes:
- Add extractTokensFromResponse (private) to parse Set-Cookie headers and map cookie names (cc-at_, cc-nx_, cc-nx-g_, idp_access_token_) back to TokenResponse fields
- Add optional enableHttpOnlySessionCookies flag (defaults to false) to: loginGuestUser, loginGuestUserPrivate, loginIDPUser, loginRegisteredUserB2C, refreshAccessToken, getPasswordLessAccessToken
- When flag is true: call getAccessToken with rawResponse=true and extract tokens from Set-Cookie headers (server-side only)
- When flag is false: existing behavior unchanged (no rawResponse)
- isBrowser check ensures tokens are never exposed on the client

Testing locally with PWA-KIT

  1. Build the SDK:
```
  cd ~/pwa/commerce-sdk-isomorphic
  yarn run build:lib && yarn pack
```
  2. Checkout feature branch [feature/httponly-session-cookies](https://github.com/SalesforceCommerceCloud/pwa-kit/tree/feature/httponly-session-cookies) and enable slas private client.
  3. In pwa-kit/packages/commerce-sdk-react/package.json:
 ` "commerce-sdk-isomorphic": "file:<path-to>/commerce-sdk-isomorphic/package.tgz"`
  4. Install from root: cd ~/pwa/V3/pwa-kit && npm install
  5. Enable private client and httponly session cookies and verify SSR requests are successful.

https://github.com/user-attachments/assets/a20a3b92-85c9-4e41-9d25-c79b62025b5f

