### PR TITLE
Feat: Support named imports via exports map (@W-22860508@)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v5.4.0
+
+### Enhancements
+
+- Support named imports via the package `exports` field, e.g. `import { ShopperLogin } from 'commerce-sdk-isomorphic'`, for bundlers and tooling that resolve `exports`. The existing default-import-and-destructure form is unchanged and fully backward compatible. [#286](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/286)
+
 ## v5.3.0
 
 _ECOM v26.6_

--- a/package.json
+++ b/package.json
@@ -11,6 +11,15 @@
     "url": "git+https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic.git"
   },
   "license": "BSD-3-Clause",
+  "exports": {
+    ".": {
+      "types": "./lib/index.cjs.d.ts",
+      "import": "./lib/index.esm.js",
+      "require": "./lib/index.cjs.js"
+    },
+    "./lib/*": "./lib/*",
+    "./package.json": "./package.json"
+  },
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
   "style": "lib/default.css",
@@ -40,7 +49,8 @@
     "renderTemplates": "PACKAGE_VERSION=$(node -p \"require('./package.json').version\") ts-node --compiler-options '{\"module\": \"commonjs\", \"target\": \"ES6\" }' ./scripts/generate-oas.ts",
     "start": "HTTPS=true react-scripts start",
     "pretest": "yarn run lint && yarn run lint:style && depcheck && yarn run check:size",
-    "test": "yarn run check:types && yarn run test:unit && CI=true yarn run test:react",
+    "test": "yarn run check:types && yarn run test:unit && yarn run test:exports && CI=true yarn run test:react",
+    "test:exports": "node --test src/test/packageExports.mjs",
     "test:react": "react-scripts test --env=jest-environment-jsdom-sixteen src/environment",
     "test:unit": "jest --coverage --testPathIgnorePatterns node_modules src/environment --silent",
     "updateApis": "ts-node --compiler-options '{\"module\": \"commonjs\", \"target\": \"ES6\" }' scripts/updateApis.ts && yarn diffApis"

--- a/src/test/packageExports.mjs
+++ b/src/test/packageExports.mjs
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Guards the package `exports` map that makes named imports resolve, e.g.
+ * `import { ShopperLogin } from 'commerce-sdk-isomorphic'`. Removing the
+ * `exports` field breaks named-import resolution for bundlers and tooling that
+ * honor it — this proves it via Node self-referencing, which only works when
+ * the field is present.
+ *
+ * Runs under `node --test`, not jest: jest 26's resolver ignores the `exports`
+ * field, so a jest test passes whether or not the field exists and would lock
+ * nothing. Node's own resolver is the one real consumers use.
+ */
+
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {createRequire} from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+test('package self-resolves by name through the exports map (require condition)', () => {
+  const sdk = require('commerce-sdk-isomorphic');
+  assert.equal(typeof sdk.ShopperLogin, 'function');
+  assert.equal(typeof sdk.helpers, 'object');
+  assert.equal(typeof sdk.ClientConfig, 'function');
+});
+
+test('the import condition resolves to the ESM bundle', async () => {
+  const resolved = await import.meta.resolve('commerce-sdk-isomorphic');
+  assert.match(resolved, /index\.esm\.js$/);
+});


### PR DESCRIPTION
## Summary
- `commerce-sdk-isomorphic` had no `exports` field, so bundlers and tooling that resolve `exports` (and TypeScript `node16`/`nodenext`) fell back to the UMD `main` and couldn't see named exports — `import { ShopperLogin } from 'commerce-sdk-isomorphic'` failed, forcing consumers to default-import and destructure.
- This adds a root `exports` map whose `import`/`require`/`types` conditions point at the **existing** ESM/CJS bundles and declarations. No bundle output changes, no source changes.
- A prior attempt added named imports bolted onto per-API subpath bundles that ~doubled package size and was reverted. This restores named imports **only** — no subpath entries, no bundle-size change (`.tgz` stays 1.09 MB < the 1.2 MB guard).

```js
// New — named imports now resolve
import { ShopperLogin, helpers } from 'commerce-sdk-isomorphic';

// Old — default import + destructure still works (unchanged)
import sdk from 'commerce-sdk-isomorphic';
const { ShopperLogin, helpers } = sdk;
```

## Test plan
- [x] `node --test src/test/packageExports.mjs` — new resolution guard, proven red when the `exports` field is removed and green with it. Runs in the `test` chain after `build:lib`.
- [x] `yarn check:types`, `yarn lint` (0 errors), `yarn test:unit` (221/221), `yarn check:size` (1.09 MB < 1.2 MB) all green.
- [x] Cross-repo smoke: built locally, linked into `pwa-kit`'s `commerce-sdk-react` (which uses named imports throughout), booted the retail storefront, and confirmed the PLP renders products via `ShopperSearch` with no SDK resolution errors.

## Verification
- Fixes named imports for bundler / `exports`-honoring consumers (the common case). Does NOT enable raw `node` native ESM (no bundler): the ESM bundle ships as `.js` (CommonJS without `"type":"module"`), and `environment.ts` resolves `node-fetch` via an eager `require` that throws under native ESM. Closing that needs a `.mjs` build + native-`fetch` migration — out of scope (the bundling surface that triggered the prior revert).

## Out of scope
- Per-API subpath exports (`commerce-sdk-isomorphic/shopperLogin`) — the reverted feature; reintroduces the size regression.
- `.mjs` ESM output + dropping `node-fetch` for native `fetch` — see Verification.

## Follow-ups
- `test:exports` requires `lib/` built first; CI and the pre-push hook build before testing, but a bare local `yarn test` without a prior `build:lib` will fail the exports test.
- `engines.node` still declares `>=12` while `node --test` / `import.meta.resolve` require Node 18+ — pre-existing.

## Ticket
W-22860508