### PR TITLE
Docs: Document node-fetch keep-alive Node regression (@W-23158959@)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,34 @@ In practice, we recommend:
 
 In the next major version release, the SDK will encode special characters (UTF-8 based on SCAPI guidelines) in path parameters by default. Please see the [Encoding special characters](#encoding-special-characters) section for more details.
 
+### Migration off node-fetch
+
+`node-fetch@2` is maintenance-only, and the upstream Node.js fix for the keep-alive regression (see [Node.js version compatibility](#nodejs-version-compatibility)) works around but does not remove the underlying `node-fetch` heuristic. A future release will replace `node-fetch` on the server path with the Node.js built-in `fetch` (available in Node 18 and later, which the SDK's current `^20.x`/`^22.x` requirement already satisfies). This will change how custom `agent` options work (built-in `fetch` is backed by undici and does not accept an `http.Agent`/`https.Agent`), and continue to honor a caller-supplied fetch via the [`fetch` client-config option](#custom-fetch-function).
+
 ## Getting Started
 
 ### Requirements
 
 - Node `^20.x` or `^22.x`
 - The SDK requires B2C Commerce API (SCAPI) to be configured. For more info see [Getting started with SCAPI](https://developer.salesforce.com/docs/commerce/commerce-api/guide/get-started.html).
+
+### Node.js version compatibility
+
+A regression in Node.js 24.17.0 and 22.23.0 caused libraries built on `node-fetch@2` to throw false `ERR_STREAM_PREMATURE_CLOSE` ("Premature close") errors when reusing keep-alive connections under load. The security fix in those releases added a listener to the socket `'data'` event, which `node-fetch@2` misreads as a truncated response ([nodejs/node#63989](https://github.com/nodejs/node/issues/63989)). It is most likely to surface on gzip-compressed, chunked responses such as large SCAPI product or search payloads.
+
+> **Note:** commerce-sdk-isomorphic **is** affected on the server (Node.js) path, because it makes HTTP requests using `node-fetch@2`. Browser builds use the platform `fetch` and are not affected. (The companion [Commerce SDK](https://github.com/SalesforceCommerceCloud/commerce-sdk), whose HTTP layer is `make-fetch-happen`, is not affected.)
+
+To resolve it, upgrade to a Node.js release that contains the [upstream fix](https://github.com/nodejs/node/pull/64004): on the 24.x line use 24.18.0 or later (avoid 24.17.0); on the 22.x line use 22.23.1 or later (avoid 22.23.0). Versions before the regression (24.16.0 and earlier, 22.22.x and earlier) do not have this bug, but they also predate the security fix it shipped alongside, so upgrade forward rather than downgrading.
+
+If you cannot change your Node.js version, avoid enabling keep-alive on the agent you pass through [`fetchOptions`](#fetch-options) (the bug only occurs when a pooled socket is reused). This removes connection pooling and adds a TLS handshake per request.
+
+Newer "Current"-line releases (Node 26.x) that shipped the same security patch are affected as well. As of June 24, 2026 no fixed 26.x release had shipped; check the [Node 26.x changelog](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V26.md) for a release that contains the [upstream fix](https://github.com/nodejs/node/pull/64004). For production, prefer an LTS line (24.x or 22.x) on the fixed versions above.
+
+References:
+
+- Regression: [nodejs/node#63989](https://github.com/nodejs/node/issues/63989) · Upstream fix: [nodejs/node#64004](https://github.com/nodejs/node/pull/64004)
+- Fixed releases: [v24.18.0](https://github.com/nodejs/node/releases/tag/v24.18.0), [v22.23.1](https://github.com/nodejs/node/releases/tag/v22.23.1)
+- Underlying `node-fetch` issue (open): [node-fetch#1767](https://github.com/node-fetch/node-fetch/issues/1767)
 
 ### Installation
 


### PR DESCRIPTION
## Summary
- Node.js 24.17.0 / 22.23.0 shipped a security fix (CVE-2026-48931, [nodejs/node#63989](https://github.com/nodejs/node/issues/63989)) that attaches a `'data'` listener to keep-alive sockets, which `node-fetch@2` misreads as a truncated response and throws false `ERR_STREAM_PREMATURE_CLOSE`. This SDK uses `node-fetch@2` on the server (Node.js) path, so consumers can hit this — most likely on gzip-compressed, chunked SCAPI product/search payloads over a reused keep-alive socket.
- Adds a "Node.js version compatibility" section (affected status, safe versions, keep-alive workaround) and a "Migration off node-fetch" note. README-only — nothing in the SDK changed.
- Synced with the sibling [commerce-sdk #451](https://github.com/SalesforceCommerceCloud/commerce-sdk/pull/451), inverted: commerce-sdk's HTTP layer is `make-fetch-happen` and is **not** affected; this SDK's is `node-fetch@2` and **is**. The two READMEs cross-reference each other, share the upgrade-forward guidance, and use the same durable Node 26.x changelog pointer (rather than a "fix forthcoming" note that rots).

## Acceptance criteria
- [x] "Node.js version compatibility" section documents the issue, affected versions (24.17.0, 22.23.0), and safe versions (24.18.0+ / 22.23.1+).
- [x] Documents the "don't pass a keep-alive agent" workaround for users stuck on an affected Node version.
- [x] "Migration off node-fetch" note covers the Node 18 fetch floor, the undici/agent change, and the `fetch` client-config escape hatch.
- [x] Links nodejs/node#63989, the fixed releases (v24.18.0 / v22.23.1), and node-fetch#1767.
- [x] Cross-links the migration follow-up — the two work items already reference each other in GUS, and the README carries a generic forward-reference (no internal ticket id in the published doc).

## Test plan
- [x] Every load-bearing fact verified against authoritative sources: the two regressed versions (24.17.0 / 22.23.0), the two fixed versions (24.18.0 / 22.23.1), the #63989 / #64004 identity, the CVE-2026-48931 mapping, and the `node-fetch@2` `listenerCount('data')` mechanism — all confirmed.
- [x] Affected claim verified locally: `node-fetch@2.6.13` is a direct dependency (`package.json`), required on the Node path at `src/lib/helpers/environment.ts` (`isNode` branch), and the buggy heuristic is present at `node_modules/node-fetch/lib/index.js:1527` / `:1745`. Browser builds use the platform `fetch` and are unaffected.
- [x] Version-matrix edges checked against the sibling PR: Node 20.x correctly omitted (EOL 2026-04-30, never received the June security patch, so never regressed); 26.x noted as affected with a live changelog pointer (no fixed 26.x release as of 2026-06-24), pointed at the LTS lines rather than a version that will rot.

## Verification
Docs-only — no behavioral surface to smoke-test, so the `/smoke-test` verifier is a documented skip (no app to drive).

**What was verified**
- All 6 external links resolve (200, not 404) and their content matches the prose: #63989, #64004, #1767, v24.18.0, v22.23.1, and the Node 26.x changelog.
- All 4 intra-doc anchors (`#nodejs-version-compatibility`, `#fetch-options`, `#custom-fetch-function`, `#encoding-special-characters`) resolve to live headings; both new subsections nest under the correct `##` parents.
- `git diff --stat` confirms `README.md` is the only file touched.

**What was NOT verified**
- Nothing outstanding — correctness for a docs change is factual accuracy of the prose, covered above.

**Interim release-note copy** (for whoever cuts the next `node-fetch`-based release — there is no release in flight, and the CHANGELOG is hand-maintained with no Unreleased section, so this lives here rather than in the repo):
> **Known issue:** On Node.js 24.17.0 and 22.23.0, this SDK's server path (`node-fetch@2`) can throw false `ERR_STREAM_PREMATURE_CLOSE` errors on reused keep-alive connections. Upgrade to Node 24.18.0+ or 22.23.1+. See the "Node.js version compatibility" section of the README.

## Out of scope
- The code migration off `node-fetch` to the Node.js built-in `fetch` — tracked as the follow-up migration ticket (cross-linked in GUS). That ticket owns the `engines` bump, the `FetchOptions` retype, and the CHANGELOG entry for the release it lands in.
- No change to the `Requirements` support matrix (`^20.x` / `^22.x`); this documents an ecosystem regression a reader might hit, not a change to what the SDK supports.

## Ticket
W-23158959